### PR TITLE
A Bulk of Features.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,15 +10,17 @@
     "bower_components",
     "output"
   ],
-  "repository": {                                              
-    "type": "git",                                             
+  "repository": {
+    "type": "git",
     "url": "git://github.com/paf31/purescript-profunctor-lenses.git"
-  },                                                            
+  },
   "devDependencies": {
     "purescript-console": "^0.1.0"
   },
   "dependencies": {
     "purescript-const": "~0.5.0",
-    "purescript-profunctor": "~0.3.0"
+    "purescript-identity": "~0.4.0",
+    "purescript-profunctor": "~0.3.0",
+    "purescript-lists": "~0.7.0"
   }
 }

--- a/src/Data/Lens.purs
+++ b/src/Data/Lens.purs
@@ -5,13 +5,19 @@
 -- | - [`module Data.Lens.Prism`](Lens/Prism.md)
 -- | - [`module Data.Lens.Traversal`](Lens/Traversal.md)
 -- | - [`module Data.Lens.Types`](Lens/Types.md)
+-- | - [`module Data.Lens.Setter`](Lens/Setter.md)
+-- | - [`module Data.Lens.Getter`](Lens/Getter.md)
+-- | - [`module Data.Lens.Fold`](Lens/Fold.md)
 
-module Data.Lens 
+module Data.Lens
   ( module Data.Lens.Iso
   , module Data.Lens.Lens
   , module Data.Lens.Prism
   , module Data.Lens.Traversal
   , module Data.Lens.Types
+  , module Data.Lens.Setter
+  , module Data.Lens.Getter
+  , module Data.Lens.Fold
   ) where
 
 import Data.Lens.Iso
@@ -19,3 +25,6 @@ import Data.Lens.Lens
 import Data.Lens.Prism
 import Data.Lens.Traversal
 import Data.Lens.Types
+import Data.Lens.Setter
+import Data.Lens.Getter
+import Data.Lens.Fold

--- a/src/Data/Lens/Fold.purs
+++ b/src/Data/Lens/Fold.purs
@@ -1,0 +1,62 @@
+-- | This module defines functions for working with getters.
+
+module Data.Lens.Fold
+  ( (^?), (^..)
+  , preview, foldOf, foldMapOf, foldrOf, foldlOf, toListOf, has, hasn't
+  ) where
+
+import Prelude
+import Data.Const
+import Data.Maybe
+import Data.List
+import Data.Maybe.First
+import Data.Monoid.Endo
+import Data.Monoid.Conj
+import Data.Monoid.Disj
+import Data.Monoid.Dual
+import Data.Profunctor.Star
+import Data.Lens.Types
+import Data.Lens.Internal.Tagged
+
+infixl 8 ^?
+infixl 8 ^..
+
+-- | Previews the first value of a fold, if there is any.
+preview :: forall s t a b. Fold (First a) s t a b -> s -> Maybe a
+preview p = runFirst <<< foldMapOf p (First <<< Just)
+
+-- | Synonym for `preview`, flipped.
+(^?) :: forall s t a b. s -> Fold (First a) s t a b -> Maybe a
+(^?) s p = preview p s
+
+-- | Folds all foci of a `Fold` to one. Note that this is the same as `view`.
+foldOf :: forall s t a b. Fold a s t a b -> s -> a
+foldOf p = getConst <<< runStar (p (Star Const))
+
+-- | Maps and then folds all foci of a `Fold`.
+foldMapOf :: forall s t a b r. Fold r s t a b -> (a -> r) -> s -> r
+foldMapOf p f = getConst <<< runStar (p (Star (Const <<< f)))
+
+-- | Right fold over a `Fold`.
+foldrOf :: forall s t a b r. Fold (Endo r) s t a b -> (a -> r -> r) -> r -> s -> r
+foldrOf p f r = flip runEndo r <<< foldMapOf p (Endo <<< f)
+
+-- | Left fold over a `Fold`.
+foldlOf :: forall s t a b r. Fold (Dual (Endo r)) s t a b -> (r -> a -> r) -> r -> s -> r
+foldlOf p f r = flip runEndo r <<< runDual <<< foldMapOf p (Dual <<< Endo <<< flip f)
+
+-- | Collects the foci of a `Fold` into a list.
+toListOf :: forall s t a b. Fold (Endo (List a)) s t a b -> s -> List a
+toListOf p = foldrOf p (:) Nil
+
+-- | Synonym for `toListOf`, reversed.
+(^..) :: forall s t a b. s -> Fold (Endo (List a)) s t a b -> List a
+(^..) s p = toListOf p s
+
+-- | Determines whether a `Fold` has at least one focus.
+has :: forall s t a b r. (BooleanAlgebra r) => Fold (Disj r) s t a b -> s -> r
+has p = runDisj <<< foldMapOf p (const (Disj top))
+
+-- | Determines whether a `Fold` does not have a focus.
+hasn't :: forall s t a b r. (BooleanAlgebra r) => Fold (Conj r) s t a b -> s -> r
+hasn't p = runConj <<< foldMapOf p (const (Conj bottom))

--- a/src/Data/Lens/Getter.purs
+++ b/src/Data/Lens/Getter.purs
@@ -1,0 +1,26 @@
+-- | This module defines functions for working with getters.
+
+module Data.Lens.Getter
+  ( (^.)
+  , view, to
+  ) where
+
+import Prelude
+import Data.Const
+import Data.Profunctor.Star
+import Data.Lens.Types
+import Data.Functor.Contravariant
+
+infixl 8 ^.
+
+-- | View the focus of a `Getter`.
+view :: forall s t a b. Getter s t a b -> s -> a
+view l s = getConst (runStar (l (Star Const)) s)
+
+-- | Synonym for `view`, flipped.
+(^.) :: forall s t a b. s -> Getter s t a b -> a
+(^.) s l = view l s
+
+-- | Convert a function into a getter.
+to :: forall s a f. (Contravariant f) => (s -> a) -> Optic (Star f) s s a a
+to f p = Star (cmap f <<< runStar p <<< f)

--- a/src/Data/Lens/Internal/Exchange.purs
+++ b/src/Data/Lens/Internal/Exchange.purs
@@ -1,0 +1,18 @@
+-- | This module defines the `Exchange` profunctor
+
+module Data.Lens.Internal.Exchange where
+
+import Prelude
+import Data.Either
+import Data.Profunctor
+import qualified Data.Bifunctor as B
+import Data.Profunctor.Choice
+
+-- | The `Exchange` profunctor characterizes an `Iso`.
+data Exchange a b s t = Exchange (s -> a) (b -> t)
+
+instance functorExchange :: Functor (Exchange a b s) where
+  map f (Exchange a b) = Exchange a (f <<< b)
+
+instance profunctorExchange :: Profunctor (Exchange a b) where
+  dimap f g (Exchange a b) = Exchange (a <<< f) (g <<< b)

--- a/src/Data/Lens/Internal/Market.purs
+++ b/src/Data/Lens/Internal/Market.purs
@@ -1,0 +1,24 @@
+-- | This module defines the `Market` profunctor
+
+module Data.Lens.Internal.Market where
+
+import Prelude
+import Data.Either
+import Data.Profunctor
+import qualified Data.Bifunctor as B
+import Data.Profunctor.Choice
+
+-- | The `Market` profunctor characterizes a `Prism`.
+data Market a b s t = Market (b -> t) (s -> Either t a)
+
+instance functorMarket :: Functor (Market a b s) where
+  map f (Market a b) = Market (f <<< a) (B.lmap f <<< b)
+
+instance profunctorMarket :: Profunctor (Market a b) where
+  dimap f g (Market a b) = Market (g <<< a) (B.lmap g <<< b <<< f)
+
+instance choiceMarket :: Choice (Market a b) where
+  left (Market x y) = Market
+    (Left <<< x) (either (B.lmap Left <<< y) (Left <<< Right))
+  right (Market x y) = Market
+    (Right <<< x) (either (Left <<< Left) (B.lmap Right <<< y))

--- a/src/Data/Lens/Internal/Tagged.purs
+++ b/src/Data/Lens/Internal/Tagged.purs
@@ -1,0 +1,19 @@
+-- | This module defines the `Tagged` profunctor
+
+module Data.Lens.Internal.Tagged where
+
+import Data.Profunctor
+import Data.Profunctor.Choice
+import Data.Either
+
+newtype Tagged a b = Tagged b
+
+instance taggedProfunctor :: Profunctor Tagged where
+  dimap _ g (Tagged x) = Tagged (g x)
+
+instance taggedChoice :: Choice Tagged where
+  left  (Tagged x) = Tagged (Left x)
+  right (Tagged x) = Tagged (Right x)
+
+unTagged :: forall a b. Tagged a b -> b
+unTagged (Tagged x) = x

--- a/src/Data/Lens/Iso.purs
+++ b/src/Data/Lens/Iso.purs
@@ -1,16 +1,44 @@
 -- | This module defines functions for working with isomorphisms.
 
-module Data.Lens.Iso 
-  ( iso
+module Data.Lens.Iso
+  ( iso, withIso, cloneIso, au, auf, under, curried, uncurried, flipped
   ) where
-    
+
 import Prelude
-    
+
 import Data.Tuple
 import Data.Lens.Types
+import Data.Lens.Internal.Exchange
 import Data.Profunctor
 import Data.Profunctor.Strong
 
 -- | Create an `Iso` from a pair of morphisms.
 iso :: forall s t a b. (s -> a) -> (b -> t) -> Iso s t a b
 iso f g pab = dimap f g pab
+
+-- | Extracts the pair of morphisms from an isomorphism.
+withIso :: forall s t a b r. AnIso s t a b -> ((s -> a) -> (b -> t) -> r) -> r
+withIso l f = case l (Exchange id id) of
+  Exchange g h -> f g h
+
+-- | Extracts an `Iso` from `AnIso`.
+cloneIso :: forall s t a b. AnIso s t a b -> Iso s t a b
+cloneIso l = withIso l dimap
+
+au :: forall s t a b e. AnIso s t a b -> ((b -> t) -> e -> s) -> e -> a
+au l = withIso l \sa bt f e -> sa (f bt e)
+
+auf :: forall s t a b e r p. (Profunctor p) => AnIso s t a b -> (p r a -> e -> b) -> p r s -> e -> t
+auf l = withIso l \sa bt f g e -> bt (f (rmap sa g) e)
+
+under :: forall s t a b. AnIso s t a b -> (t -> s) -> b -> a
+under l = withIso l \sa bt ts -> sa <<< ts <<< bt
+
+curried :: forall a b c d e f. Iso (Tuple a b -> c) (Tuple d e -> f) (a -> b -> c) (d -> e -> f)
+curried = iso curry uncurry
+
+uncurried :: forall a b c d e f. Iso (a -> b -> c) (d -> e -> f) (Tuple a b -> c) (Tuple d e -> f)
+uncurried = iso uncurry curry
+
+flipped :: forall a b c d e f. Iso (a -> b -> c) (d -> e -> f) (b -> a -> c) (e -> d -> f)
+flipped = iso flip flip

--- a/src/Data/Lens/Lens.purs
+++ b/src/Data/Lens/Lens.purs
@@ -1,18 +1,15 @@
 -- | This module defines functions for working with lenses.
 
-module Data.Lens.Lens 
+module Data.Lens.Lens
   ( lens
   , lens'
-  , view
   ) where
-    
+
 import Prelude
-    
-import Data.Const
+
 import Data.Tuple
 import Data.Lens.Types
 import Data.Profunctor
-import Data.Profunctor.Star
 import Data.Profunctor.Strong
 
 lens' :: forall s t a b. (s -> Tuple a (b -> t)) -> Lens s t a b
@@ -21,7 +18,3 @@ lens' to pab = dimap to (\(Tuple b f) -> f b) (first pab)
 -- | Create a `Lens` from a getter/setter pair.
 lens :: forall s t a b. (s -> a) -> (s -> b -> t) -> Lens s t a b
 lens get set = lens' \s -> Tuple (get s) \b -> set s b
-
--- | View the focus of a `Lens`.
-view :: forall s t a b. Lens s t a b -> s -> a
-view l s = getConst (runStar (l (Star Const)) s)

--- a/src/Data/Lens/Prism.purs
+++ b/src/Data/Lens/Prism.purs
@@ -1,11 +1,16 @@
 -- | This module defines functions for working with lenses.
 
 module Data.Lens.Prism where
-    
+
 import Prelude
-    
+
 import Data.Either
+import Data.Profunctor.Star
+import Data.Const
+import Data.Maybe
+import Data.Maybe.First
 import Data.Lens.Types
+import Data.Lens.Internal.Tagged
 import Data.Profunctor (dimap, rmap)
 import Data.Profunctor.Choice (left)
 
@@ -13,3 +18,10 @@ import Data.Profunctor.Choice (left)
 prism :: forall s t a b. (b -> t) -> (s -> Either a t) -> Prism s t a b
 prism to fro pab = dimap fro (either id id) (left (rmap to pab))
 
+-- | Review a value through a `Prism`.
+review :: forall s t a b. Prism s t a b -> b -> t
+review p = unTagged <<< p <<< Tagged
+
+-- | Previews the value of a `Prism`, if there is any.
+preview :: forall s t a b. Prism s t a b -> s -> Maybe a
+preview p = runFirst <<< getConst <<< runStar (p (Star (Const <<< pure)))

--- a/src/Data/Lens/Prism.purs
+++ b/src/Data/Lens/Prism.purs
@@ -1,6 +1,9 @@
 -- | This module defines functions for working with lenses.
 
-module Data.Lens.Prism where
+module Data.Lens.Prism
+  ( prism, prism', review, nearly, only, clonePrism, withPrism, matching
+  , is, isn't
+  ) where
 
 import Prelude
 
@@ -11,17 +14,42 @@ import Data.Maybe
 import Data.Maybe.First
 import Data.Lens.Types
 import Data.Lens.Internal.Tagged
+import Data.Lens.Internal.Market
+import Control.MonadPlus
 import Data.Profunctor (dimap, rmap)
-import Data.Profunctor.Choice (left)
+import Data.Profunctor.Choice
 
 -- | Create a `Prism` from a constructor/pattern pair.
-prism :: forall s t a b. (b -> t) -> (s -> Either a t) -> Prism s t a b
-prism to fro pab = dimap fro (either id id) (left (rmap to pab))
+prism :: forall s t a b. (b -> t) -> (s -> Either t a) -> Prism s t a b
+prism to fro pab = dimap fro (either id id) (right (rmap to pab))
+
+prism' :: forall s a. (a -> s) -> (s -> Maybe a) -> PrismP s a
+prism' to fro = prism to (\s -> maybe (Left s) Right (fro s))
 
 -- | Review a value through a `Prism`.
-review :: forall s t a b. Prism s t a b -> b -> t
+review :: forall s t a b. Review s t a b -> b -> t
 review p = unTagged <<< p <<< Tagged
 
--- | Previews the value of a `Prism`, if there is any.
-preview :: forall s t a b. Prism s t a b -> s -> Maybe a
-preview p = runFirst <<< getConst <<< runStar (p (Star (Const <<< pure)))
+nearly :: forall a. a -> (a -> Boolean) -> PrismP a Unit
+nearly x f = prism' (const x) (guard <<< f)
+
+only :: forall a. (Eq a) => a -> Prism a a Unit Unit
+only x = nearly x (== x)
+
+clonePrism :: forall s t a b. APrism s t a b -> Prism s t a b
+clonePrism l = withPrism l go where
+  -- the type checker doesn't like `prism` for `go`...
+  go to fro pab = dimap fro (either id id) (right (rmap to pab))
+
+withPrism :: forall s t a b r. APrism s t a b -> ((b -> t) -> (s -> Either t a) -> r) -> r
+withPrism l f = case l (Market id Right) of
+  Market g h -> f g h
+
+matching :: forall s t a b. APrism s t a b -> s -> Either t a
+matching l = withPrism l \_ f -> f
+
+is :: forall s t a b r. (BooleanAlgebra r) => APrism s t a b -> s -> r
+is l = either (const bottom) (const top) <<< matching l
+
+isn't :: forall s t a b r. (BooleanAlgebra r) => APrism s t a b -> s -> r
+isn't l = not <<< is l

--- a/src/Data/Lens/Setter.purs
+++ b/src/Data/Lens/Setter.purs
@@ -1,0 +1,67 @@
+-- | This module defines functions for working with setters.
+
+module Data.Lens.Setter
+  ( (%~), (.~), (+~), (-~), (*~), (//~), (||~), (&&~), (<>~), (++~), (?~)
+  , over, set
+  ) where
+
+import Prelude
+import Data.Const
+import Data.Profunctor.Star
+import Data.Lens.Types
+import Data.Maybe
+
+infixr 4 %~
+infixr 4 .~
+infixr 4 +~
+infixr 4 -~
+infixr 4 *~
+infixr 4 //~
+infixr 4 ||~
+infixr 4 &&~
+infixr 4 <>~
+infixr 4 ++~
+infixr 4 ?~
+
+-- | Apply a function to the foci of a `Setter`.
+over :: forall s t a b. Setter s t a b -> (a -> b) -> s -> t
+over l = l
+
+-- | Synonym for `over`.
+(%~) :: forall s t a b. Setter s t a b -> (a -> b) -> s -> t
+(%~) = over
+
+-- | Set the foci of a `Setter` to a constant value.
+set :: forall s t a b. Setter s t a b -> b -> s -> t
+set l b = over l (const b)
+
+-- | Synonym for `set`.
+(.~) :: forall s t a b. Setter s t a b -> b -> s -> t
+(.~) = set
+
+(+~) :: forall s t a a. (Semiring a) => Setter s t a a -> a -> s -> t
+(+~) p = over p <<< flip (+)
+
+(*~) :: forall s t a a. (Semiring a) => Setter s t a a -> a -> s -> t
+(*~) p = over p <<< flip (*)
+
+(-~) :: forall s t a a. (Ring a) => Setter s t a a -> a -> s -> t
+(-~) p = over p <<< flip (-)
+
+(//~) :: forall s t a a. (DivisionRing a) => Setter s t a a -> a -> s -> t
+(//~) p = over p <<< flip (/)
+
+(||~) :: forall s t a a. (BooleanAlgebra a) => Setter s t a a -> a -> s -> t
+(||~) p = over p <<< flip (||)
+
+(&&~) :: forall s t a a. (BooleanAlgebra a) => Setter s t a a -> a -> s -> t
+(&&~) p = over p <<< flip (&&)
+
+(<>~) :: forall s t a a. (Semigroup a) => Setter s t a a -> a -> s -> t
+(<>~) p = over p <<< flip (<>)
+
+(++~) :: forall s t a a. (Semigroup a) => Setter s t a a -> a -> s -> t
+(++~) p = over p <<< flip (++)
+
+(?~) :: forall s t a b. Setter s t a (Maybe b) -> b -> s -> t
+(?~) p = set p <<< Just

--- a/src/Data/Lens/Traversal.purs
+++ b/src/Data/Lens/Traversal.purs
@@ -1,14 +1,14 @@
 -- | This module defines functions for working with traversals.
 
-module Data.Lens.Traversal 
+module Data.Lens.Traversal
   ( traverse
   , traverseOf
   , over
   , viewAll
   ) where
-    
+
 import Prelude
-    
+
 import Data.Const
 import Data.Monoid
 import Data.Lens.Types
@@ -23,11 +23,3 @@ traverse = wander
 -- | Turn a pure profunctor `Traversal` into a `lens`-like `Traversal`.
 traverseOf :: forall f s t a b. (Applicative f) => Traversal s t a b -> (a -> f b) -> s -> f t
 traverseOf t f = runStar (t (Star f))
-
--- | Apply a function to the foci of a `Traversal`.
-over :: forall s t a b. Traversal s t a b -> (a -> b) -> s -> t
-over l = l
-
--- | View the foci of a `Traversal`, combining results in some `Monoid`.
-viewAll :: forall s t a b m. (Monoid m) => Traversal s t a b -> (a -> m) -> s -> m
-viewAll l f = getConst <<< runStar (l (Star (Const <<< f)))

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -1,26 +1,58 @@
 -- | This module defines functions for working with lenses.
 
 module Data.Lens.Types where
-    
+
 import Prelude
 
 import Data.Profunctor
+import Data.Profunctor.Star
 import Data.Profunctor.Strong
 import Data.Profunctor.Choice
+import Data.Maybe.First
+import Data.Const
 
 import Data.Lens.Internal.Wander
+import Data.Lens.Internal.Tagged
+import Data.Lens.Internal.Exchange
+import Data.Lens.Internal.Market
 
 -- | A general-purpose optic.
 type Optic p s t a b = p a b -> p s t
+type OpticP p s a = Optic p s s a a
 
 -- | A generalized isomorphism.
 type Iso s t a b = forall p. (Profunctor p) => Optic p s t a b
+type IsoP s a = Iso s s a a
+
+type AnIso s t a b = Optic (Exchange a b) s t a b
+type AnIsoP s a = AnIso s s a a
 
 -- | A lens.
 type Lens s t a b = forall p. (Strong p) => Optic p s t a b
+type LensP s a = Lens s s a a
 
 -- | A prism.
 type Prism s t a b = forall p. (Choice p) => Optic p s t a b
+type PrismP s a = Prism s s a a
+
+type APrism s t a b = Optic (Market a b) s t a b
+type APrismP s a = APrism s s a a
 
 -- | A traversal.
 type Traversal s t a b = forall p. (Wander p) => Optic p s t a b
+
+-- | A getter.
+type Getter s t a b = Fold a s t a b
+type GetterP s a = Getter s s a a
+
+-- | A setter.
+type Setter s t a b = Optic Function s t a b
+type SetterP s a = Setter s s a a
+
+-- | A review.
+type Review s t a b = Optic Tagged s t a b
+type ReviewP s a = Review s s a a
+
+-- | A fold.
+type Fold r s t a b = Optic (Star (Const r)) s t a b
+type FoldP r s a = Fold r s s a a


### PR DESCRIPTION
I want to move towards feature parity with `purescript-lens` and `purescript-optic` as fast as possible. This PR includes:
- `Getter`s, `Setter`s and `Fold`s. Special types for special purposes and functions with specialized signatures: e.g. `view` doesn't need a `Lens`, it needs a `Getter`. Since traversals with monoid targets are also `Getter`s, this makes `viewAll` obsolete.
- A lot of folds: `foldOf`, `foldMapOf`, `foldrOf`, `foldlOf`, `toList`, `preview` etc.
- Some utility functions for `Prism`s and `Iso`s.
- `AnIso` and `APrism`, with the functions to convert between the representations.
- Operators: `.~`, `%~`, `^.` `^..` and auxiliary operators for `Setter`s like `||~`
