### PR TITLE
Wander, some Folds and ALens; corrected.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "purescript-const": "~0.5.0",
     "purescript-identity": "~0.4.0",
     "purescript-profunctor": "~0.3.0",
-    "purescript-lists": "~0.7.0"
+    "purescript-lists": "~0.7.0",
+    "purescript-unsafe-coerce": "~0.1.0"
   }
 }

--- a/docs/Data/Lens.md
+++ b/docs/Data/Lens.md
@@ -10,5 +10,6 @@ This module re-exports types and functions from other modules:
 - [`module Data.Lens.Setter`](Lens/Setter.md)
 - [`module Data.Lens.Getter`](Lens/Getter.md)
 - [`module Data.Lens.Fold`](Lens/Fold.md)
+- [`module Data.Lens.Common`](Lens/Common.md)
 
 

--- a/docs/Data/Lens/Common.md
+++ b/docs/Data/Lens/Common.md
@@ -1,0 +1,67 @@
+## Module Data.Lens.Common
+
+This module defines common lenses and prisms.
+
+#### `_Nothing`
+
+``` purescript
+_Nothing :: forall a b. Prism (Maybe a) (Maybe b) Unit Unit
+```
+
+#### `_Just`
+
+``` purescript
+_Just :: forall a b. Prism (Maybe a) (Maybe b) a b
+```
+
+Prism for the `Just` constructor of `Maybe`.
+
+#### `_Left`
+
+``` purescript
+_Left :: forall a b c. Prism (Either a c) (Either b c) a b
+```
+
+Prism for the `Left` constructor of `Either`.
+
+#### `_Right`
+
+``` purescript
+_Right :: forall a b c. Prism (Either c a) (Either c b) a b
+```
+
+Prism for the `Right` constructor of `Either`.
+
+#### `_1`
+
+``` purescript
+_1 :: forall a b c. Lens (Tuple a c) (Tuple b c) a b
+```
+
+Lens for the first component of a `Tuple`.
+
+#### `_2`
+
+``` purescript
+_2 :: forall a b c. Lens (Tuple c a) (Tuple c b) a b
+```
+
+Lens for the second component of a `Tuple`.
+
+#### `united`
+
+``` purescript
+united :: forall a. LensP a Unit
+```
+
+There is a `Unit` in everything.
+
+#### `devoid`
+
+``` purescript
+devoid :: forall a. LensP Void a
+```
+
+There is everything in `Void`.
+
+

--- a/docs/Data/Lens/Fold.md
+++ b/docs/Data/Lens/Fold.md
@@ -52,6 +52,127 @@ foldlOf :: forall s t a b r. Fold (Dual (Endo r)) s t a b -> (r -> a -> r) -> r 
 
 Left fold over a `Fold`.
 
+#### `allOf`
+
+``` purescript
+allOf :: forall s t a b r. (BooleanAlgebra r) => Fold (Conj r) s t a b -> (a -> r) -> s -> r
+```
+
+Whether all foci of a `Fold` satisfy a predicate.
+
+#### `anyOf`
+
+``` purescript
+anyOf :: forall s t a b r. (BooleanAlgebra r) => Fold (Disj r) s t a b -> (a -> r) -> s -> r
+```
+
+Whether any focus of a `Fold` satisfies a predicate.
+
+#### `andOf`
+
+``` purescript
+andOf :: forall s t a b. (BooleanAlgebra a) => Fold (Conj a) s t a b -> s -> a
+```
+
+The conjunction of all foci of a `Fold`.
+
+#### `orOf`
+
+``` purescript
+orOf :: forall s t a b. (BooleanAlgebra a) => Fold (Disj a) s t a b -> s -> a
+```
+
+The disjunction of all foci of a `Fold`.
+
+#### `elemOf`
+
+``` purescript
+elemOf :: forall s t a b. (Eq a) => Fold (Disj Boolean) s t a b -> a -> s -> Boolean
+```
+
+Whether a `Fold` contains a given element.
+
+#### `notElemOf`
+
+``` purescript
+notElemOf :: forall s t a b. (Eq a) => Fold (Conj Boolean) s t a b -> a -> s -> Boolean
+```
+
+Whether a `Fold` not contains a given element.
+
+#### `sumOf`
+
+``` purescript
+sumOf :: forall s t a b. (Semiring a) => Fold (Additive a) s t a b -> s -> a
+```
+
+The sum of all foci of a `Fold`.
+
+#### `productOf`
+
+``` purescript
+productOf :: forall s t a b. (Semiring a) => Fold (Multiplicative a) s t a b -> s -> a
+```
+
+The product of all foci of a `Fold`.
+
+#### `lengthOf`
+
+``` purescript
+lengthOf :: forall s t a b. Fold (Additive Int) s t a b -> s -> Int
+```
+
+The number of foci of a `Fold`.
+
+#### `firstOf`
+
+``` purescript
+firstOf :: forall s t a b. Fold (First a) s t a b -> s -> Maybe a
+```
+
+The first focus of a `Fold`, if there is any. Synonym for `preview`.
+
+#### `lastOf`
+
+``` purescript
+lastOf :: forall s t a b. Fold (Last a) s t a b -> s -> Maybe a
+```
+
+The last focus of a `Fold`, if there is any.
+
+#### `maximumOf`
+
+``` purescript
+maximumOf :: forall s t a b. (Ord a) => Fold (Endo (Maybe a)) s t a b -> s -> Maybe a
+```
+
+The maximum of all foci of a `Fold`, if there is any.
+
+#### `minimumOf`
+
+``` purescript
+minimumOf :: forall s t a b. (Ord a) => Fold (Endo (Maybe a)) s t a b -> s -> Maybe a
+```
+
+The minimum of all foci of a `Fold`, if there is any.
+
+#### `findOf`
+
+``` purescript
+findOf :: forall s t a b. Fold (Endo (Maybe a)) s t a b -> (a -> Boolean) -> s -> Maybe a
+```
+
+Find the first focus of a `Fold` that satisfies a predicate, if there is any.
+
+#### `sequenceOf_`
+
+``` purescript
+sequenceOf_ :: forall f s t a b. (Applicative f) => Fold (Endo (f Unit)) s t (f a) b -> s -> f Unit
+```
+
+Sequence the foci of a `Fold`, pulling out an `Applicative`, and ignore
+the result. If you need the result, see `sequenceOf` for `Traversal`s.
+
 #### `toListOf`
 
 ``` purescript

--- a/docs/Data/Lens/Fold.md
+++ b/docs/Data/Lens/Fold.md
@@ -86,4 +86,20 @@ hasn't :: forall s t a b r. (BooleanAlgebra r) => Fold (Conj r) s t a b -> s -> 
 
 Determines whether a `Fold` does not have a focus.
 
+#### `filtered`
+
+``` purescript
+filtered :: forall p a. (Choice p) => (a -> Boolean) -> OpticP p a a
+```
+
+Filters on a predicate.
+
+#### `replicated`
+
+``` purescript
+replicated :: forall r a b t f. (Applicative f, Contravariant f) => Int -> Optic (Star f) a b a t
+```
+
+Replicates the elements of a fold.
+
 

--- a/docs/Data/Lens/Internal/Shop.md
+++ b/docs/Data/Lens/Internal/Shop.md
@@ -1,0 +1,20 @@
+## Module Data.Lens.Internal.Shop
+
+This module defines the `Shop` profunctor
+
+#### `Shop`
+
+``` purescript
+data Shop a b s t
+  = Shop (s -> a) (s -> b -> t)
+```
+
+The `Shop` profunctor characterizes a `Lens`.
+
+##### Instances
+``` purescript
+instance profunctorShop :: Profunctor (Shop a b)
+instance strongShop :: Strong (Shop a b)
+```
+
+

--- a/docs/Data/Lens/Internal/Void.md
+++ b/docs/Data/Lens/Internal/Void.md
@@ -1,0 +1,23 @@
+## Module Data.Lens.Internal.Void
+
+This module defines the empty `Void` type.
+
+#### `Void`
+
+``` purescript
+data Void
+```
+
+#### `absurd`
+
+``` purescript
+absurd :: forall a. Void -> a
+```
+
+#### `coerce`
+
+``` purescript
+coerce :: forall f a b. (Contravariant f, Functor f) => f a -> f b
+```
+
+

--- a/docs/Data/Lens/Internal/Wander.md
+++ b/docs/Data/Lens/Internal/Wander.md
@@ -5,9 +5,11 @@ This module defines the `Wander` type class, which is used to define `Traversal`
 #### `Wander`
 
 ``` purescript
-class (Strong p, Choice p) <= Wander p where
-  wander :: forall t a b. (Traversable t) => p a b -> p (t a) (t b)
+class (Strong p) <= Wander p where
+  wander :: forall f s t a b. (forall f. (Applicative f) => (a -> f b) -> s -> f t) -> p a b -> p s t
 ```
+
+Class for profunctors that support polymorphic traversals.
 
 ##### Instances
 ``` purescript

--- a/docs/Data/Lens/Internal/Wander.md
+++ b/docs/Data/Lens/Internal/Wander.md
@@ -5,7 +5,7 @@ This module defines the `Wander` type class, which is used to define `Traversal`
 #### `Wander`
 
 ``` purescript
-class (Strong p) <= Wander p where
+class (Strong p, Choice p) <= Wander p where
   wander :: forall f s t a b. (forall f. (Applicative f) => (a -> f b) -> s -> f t) -> p a b -> p s t
 ```
 

--- a/docs/Data/Lens/Lens.md
+++ b/docs/Data/Lens/Lens.md
@@ -16,4 +16,16 @@ lens :: forall s t a b. (s -> a) -> (s -> b -> t) -> Lens s t a b
 
 Create a `Lens` from a getter/setter pair.
 
+#### `withLens`
+
+``` purescript
+withLens :: forall s t a b r. ALens s t a b -> ((s -> a) -> (s -> b -> t) -> r) -> r
+```
+
+#### `cloneLens`
+
+``` purescript
+cloneLens :: forall s t a b. ALens s t a b -> Lens s t a b
+```
+
 

--- a/docs/Data/Lens/Traversal.md
+++ b/docs/Data/Lens/Traversal.md
@@ -2,10 +2,10 @@
 
 This module defines functions for working with traversals.
 
-#### `traverse`
+#### `traversed`
 
 ``` purescript
-traverse :: forall t a b. (Traversable t) => Traversal (t a) (t b) a b
+traversed :: forall t a b. (Traversable t) => Traversal (t a) (t b) a b
 ```
 
 Create a `Traversal` which traverses the elements of a `Traversable` functor.
@@ -13,9 +13,27 @@ Create a `Traversal` which traverses the elements of a `Traversable` functor.
 #### `traverseOf`
 
 ``` purescript
-traverseOf :: forall f s t a b. (Applicative f) => Traversal s t a b -> (a -> f b) -> s -> f t
+traverseOf :: forall f s t a b. (Applicative f) => Optic (Star f) s t a b -> (a -> f b) -> s -> f t
 ```
 
 Turn a pure profunctor `Traversal` into a `lens`-like `Traversal`.
+
+#### `sequenceOf`
+
+``` purescript
+sequenceOf :: forall f s t a. (Applicative f) => Optic (Star f) s t (f a) a -> s -> f t
+```
+
+Sequence the foci of a `Traversal`, pulling out an `Applicative` effect.
+If you do not need the result, see `sequenceOf_` for `Fold`s.
+
+#### `failover`
+
+``` purescript
+failover :: forall f s t a b. (Alternative f) => Optic (Star (Tuple (Disj Boolean))) s t a b -> (a -> b) -> s -> f t
+```
+
+Tries to map over a `Traversal`; returns `empty`, if the traversal did
+not have any new focus.
 
 

--- a/docs/Data/Lens/Types.md
+++ b/docs/Data/Lens/Types.md
@@ -56,6 +56,18 @@ A lens.
 type LensP s a = Lens s s a a
 ```
 
+#### `ALens`
+
+``` purescript
+type ALens s t a b = Optic (Shop a b) s t a b
+```
+
+#### `ALensP`
+
+``` purescript
+type ALensP s a = ALens s s a a
+```
+
 #### `Prism`
 
 ``` purescript

--- a/src/Data/Lens.purs
+++ b/src/Data/Lens.purs
@@ -8,6 +8,7 @@
 -- | - [`module Data.Lens.Setter`](Lens/Setter.md)
 -- | - [`module Data.Lens.Getter`](Lens/Getter.md)
 -- | - [`module Data.Lens.Fold`](Lens/Fold.md)
+-- | - [`module Data.Lens.Common`](Lens/Common.md)
 
 module Data.Lens
   ( module Data.Lens.Iso
@@ -18,6 +19,7 @@ module Data.Lens
   , module Data.Lens.Setter
   , module Data.Lens.Getter
   , module Data.Lens.Fold
+  , module Data.Lens.Common
   ) where
 
 import Data.Lens.Iso
@@ -28,3 +30,4 @@ import Data.Lens.Types
 import Data.Lens.Setter
 import Data.Lens.Getter
 import Data.Lens.Fold
+import Data.Lens.Common

--- a/src/Data/Lens/Common.purs
+++ b/src/Data/Lens/Common.purs
@@ -1,0 +1,45 @@
+-- | This module defines common lenses and prisms.
+
+module Data.Lens.Common where
+--------------------------------------------------------------------------------
+import Prelude
+import Data.Maybe
+import Data.Either
+import Data.Tuple
+import Data.Lens.Types
+import Data.Lens.Prism
+import Data.Lens.Lens
+import Data.Lens.Internal.Void
+--------------------------------------------------------------------------------
+
+-- | Prism for the `Nothing` constructor of `Maybe`.
+_Nothing :: forall a b. Prism (Maybe a) (Maybe b) Unit Unit
+_Nothing = prism (const Nothing) $ maybe (Right unit) (const $ Left Nothing)
+
+-- | Prism for the `Just` constructor of `Maybe`.
+_Just :: forall a b. Prism (Maybe a) (Maybe b) a b
+_Just = prism Just $ maybe (Left Nothing) Right
+
+-- | Prism for the `Left` constructor of `Either`.
+_Left :: forall a b c. Prism (Either a c) (Either b c) a b
+_Left = prism Left $ either Right (Left <<< Right)
+
+-- | Prism for the `Right` constructor of `Either`.
+_Right :: forall a b c. Prism (Either c a) (Either c b) a b
+_Right = prism Right $ either (Left <<< Left) Right
+
+-- | Lens for the first component of a `Tuple`.
+_1 :: forall a b c. Lens (Tuple a c) (Tuple b c) a b
+_1 = lens (\(Tuple a _) -> a) \(Tuple _ c) b -> Tuple b c
+
+-- | Lens for the second component of a `Tuple`.
+_2 :: forall a b c. Lens (Tuple c a) (Tuple c b) a b
+_2 = lens (\(Tuple _ a) -> a) \(Tuple c _) b -> Tuple c b
+
+-- | There is a `Unit` in everything.
+united :: forall a. LensP a Unit
+united = lens (const unit) const
+
+-- | There is everything in `Void`.
+devoid :: forall a. LensP Void a
+devoid = lens absurd const

--- a/src/Data/Lens/Fold.purs
+++ b/src/Data/Lens/Fold.purs
@@ -2,8 +2,9 @@
 
 module Data.Lens.Fold
   ( (^?), (^..)
-  , preview, foldOf, foldMapOf, foldrOf, foldlOf, toListOf, has, hasn't
-  , replicated, filtered
+  , preview, foldOf, foldMapOf, foldrOf, foldlOf, toListOf, firstOf, lastOf
+  , maximumOf, minimumOf, allOf, anyOf, andOf, orOf, elemOf, notElemOf, sumOf
+  , productOf, lengthOf, findOf, sequenceOf_, has, hasn't, replicated, filtered
   ) where
 
 import Prelude
@@ -11,12 +12,16 @@ import Data.Const
 import Data.Maybe
 import Data.List
 import Data.Either
+import Data.Tuple
 import Data.Monoid
 import Data.Maybe.First
+import Data.Maybe.Last
 import Data.Monoid.Endo
 import Data.Monoid.Conj
 import Data.Monoid.Disj
 import Data.Monoid.Dual
+import Data.Monoid.Additive
+import Data.Monoid.Multiplicative
 import Data.Functor.Contravariant
 import Data.Foldable
 import Data.Profunctor
@@ -54,6 +59,69 @@ foldrOf p f r = flip runEndo r <<< foldMapOf p (Endo <<< f)
 foldlOf :: forall s t a b r. Fold (Dual (Endo r)) s t a b -> (r -> a -> r) -> r -> s -> r
 foldlOf p f r = flip runEndo r <<< runDual <<< foldMapOf p (Dual <<< Endo <<< flip f)
 
+-- | Whether all foci of a `Fold` satisfy a predicate.
+allOf :: forall s t a b r. (BooleanAlgebra r) => Fold (Conj r) s t a b -> (a -> r) -> s -> r
+allOf p f = runConj <<< foldMapOf p (Conj <<< f)
+
+-- | Whether any focus of a `Fold` satisfies a predicate.
+anyOf :: forall s t a b r. (BooleanAlgebra r) => Fold (Disj r) s t a b -> (a -> r) -> s -> r
+anyOf p f = runDisj <<< foldMapOf p (Disj <<< f)
+
+-- | The conjunction of all foci of a `Fold`.
+andOf :: forall s t a b. (BooleanAlgebra a) => Fold (Conj a) s t a b -> s -> a
+andOf p = allOf p id
+
+-- | The disjunction of all foci of a `Fold`.
+orOf :: forall s t a b. (BooleanAlgebra a) => Fold (Disj a) s t a b -> s -> a
+orOf p = anyOf p id
+
+-- | Whether a `Fold` contains a given element.
+elemOf :: forall s t a b. (Eq a) => Fold (Disj Boolean) s t a b -> a -> s -> Boolean
+elemOf p a = anyOf p (== a)
+
+-- | Whether a `Fold` not contains a given element.
+notElemOf :: forall s t a b. (Eq a) => Fold (Conj Boolean) s t a b -> a -> s -> Boolean
+notElemOf p a = allOf p (/= a)
+
+-- | The sum of all foci of a `Fold`.
+sumOf :: forall s t a b. (Semiring a) => Fold (Additive a) s t a b -> s -> a
+sumOf p = runAdditive <<< foldMapOf p Additive
+
+-- | The product of all foci of a `Fold`.
+productOf :: forall s t a b. (Semiring a) => Fold (Multiplicative a) s t a b -> s -> a
+productOf p = runMultiplicative <<< foldMapOf p Multiplicative
+
+-- | The number of foci of a `Fold`.
+lengthOf :: forall s t a b. Fold (Additive Int) s t a b -> s -> Int
+lengthOf p = runAdditive <<< foldMapOf p (const $ Additive 1)
+
+-- | The first focus of a `Fold`, if there is any. Synonym for `preview`.
+firstOf :: forall s t a b. Fold (First a) s t a b -> s -> Maybe a
+firstOf p = runFirst <<< foldMapOf p (First <<< Just)
+
+-- | The last focus of a `Fold`, if there is any.
+lastOf :: forall s t a b. Fold (Last a) s t a b -> s -> Maybe a
+lastOf p = runLast <<< foldMapOf p (Last <<< Just)
+
+-- | The maximum of all foci of a `Fold`, if there is any.
+maximumOf :: forall s t a b. (Ord a) => Fold (Endo (Maybe a)) s t a b -> s -> Maybe a
+maximumOf p = foldrOf p (\a -> Just <<< maybe a (max a)) Nothing where
+  max a b = if a > b then a else b
+
+-- | The minimum of all foci of a `Fold`, if there is any.
+minimumOf :: forall s t a b. (Ord a) => Fold (Endo (Maybe a)) s t a b -> s -> Maybe a
+minimumOf p = foldrOf p (\a -> Just <<< maybe a (min a)) Nothing where
+  min a b = if a > b then a else b
+
+-- | Find the first focus of a `Fold` that satisfies a predicate, if there is any.
+findOf :: forall s t a b. Fold (Endo (Maybe a)) s t a b -> (a -> Boolean) -> s -> Maybe a
+findOf p f = foldrOf p (\a -> maybe (if f a then Just a else Nothing) Just) Nothing
+
+-- | Sequence the foci of a `Fold`, pulling out an `Applicative`, and ignore
+-- | the result. If you need the result, see `sequenceOf` for `Traversal`s.
+sequenceOf_ :: forall f s t a b. (Applicative f) => Fold (Endo (f Unit)) s t (f a) b -> s -> f Unit
+sequenceOf_ p = flip runEndo (pure unit) <<< foldMapOf p \f -> Endo (f *>)
+
 -- | Collects the foci of a `Fold` into a list.
 toListOf :: forall s t a b. Fold (Endo (List a)) s t a b -> s -> List a
 toListOf p = foldrOf p (:) Nil
@@ -87,3 +155,10 @@ folded
   :: forall f g a b t r. (Applicative f, Contravariant f, Foldable g)
   => Optic (Star f) (g a) b a t
 folded p = Star $ foldr (\a r -> runStar p a *> r) (coerce $ pure unit)
+
+-- | Builds a `Fold` using an unfold.
+unfolded
+  :: forall f s t a b. (Applicative f, Contravariant f)
+  => (s -> Maybe (Tuple a s)) -> Optic (Star f) s t a b
+unfolded f p = Star go where
+  go = maybe (coerce $ pure unit) (\(Tuple a s) -> runStar p a *> go s) <<< f

--- a/src/Data/Lens/Internal/Shop.purs
+++ b/src/Data/Lens/Internal/Shop.purs
@@ -1,0 +1,18 @@
+-- | This module defines the `Shop` profunctor
+
+module Data.Lens.Internal.Shop where
+
+import Prelude
+import Data.Tuple
+import Data.Profunctor
+import Data.Profunctor.Strong
+
+-- | The `Shop` profunctor characterizes a `Lens`.
+data Shop a b s t = Shop (s -> a) (s -> b -> t)
+
+instance profunctorShop :: Profunctor (Shop a b) where
+  dimap f g (Shop x y) = Shop (x <<< f) (\s -> g <<< y (f s))
+
+instance strongShop :: Strong (Shop a b) where
+  first (Shop x y) = Shop (\(Tuple a _) -> x a) (\(Tuple s c) b -> Tuple (y s b) c)
+  second (Shop x y) = Shop (\(Tuple _ a) -> x a) (\(Tuple c s) b -> Tuple c (y s b))

--- a/src/Data/Lens/Internal/Void.purs
+++ b/src/Data/Lens/Internal/Void.purs
@@ -1,0 +1,15 @@
+-- | This module defines the empty `Void` type.
+
+module Data.Lens.Internal.Void where
+
+import Prelude
+import Data.Functor.Contravariant
+import Unsafe.Coerce
+
+data Void
+
+absurd :: forall a. Void -> a
+absurd = unsafeCoerce
+
+coerce :: forall f a b. (Contravariant f, Functor f) => f a -> f b
+coerce a = absurd <$> (absurd >$< a)

--- a/src/Data/Lens/Internal/Wander.purs
+++ b/src/Data/Lens/Internal/Wander.purs
@@ -1,19 +1,21 @@
 -- | This module defines the `Wander` type class, which is used to define `Traversal`s.
 
 module Data.Lens.Internal.Wander where
-    
+
 import Prelude
 
-import Data.Traversable (Traversable, traverse)
 import Data.Profunctor.Strong (Strong)
-import Data.Profunctor.Choice (Choice)
-import Data.Profunctor.Star (Star(..))
+import Data.Profunctor.Star (Star(..), runStar)
+import Data.Identity (Identity (..), runIdentity)
 
-class (Strong p, Choice p) <= Wander p where
-  wander :: forall t a b. (Traversable t) => p a b -> p (t a) (t b)
-  
+-- | Class for profunctors that support polymorphic traversals.
+class (Strong p) <= Wander p where
+  wander
+    :: forall f s t a b. (forall f. (Applicative f) => (a -> f b) -> s -> f t)
+    -> p a b -> p s t
+
 instance wanderFunction :: Wander Function where
-  wander = map
+  wander t f s = runIdentity $ t (Identity <<< f) s
 
 instance wanderStar :: (Applicative f) => Wander (Star f) where
-  wander (Star f) = Star (traverse f)
+  wander t = Star <<< t <<< runStar

--- a/src/Data/Lens/Internal/Wander.purs
+++ b/src/Data/Lens/Internal/Wander.purs
@@ -5,11 +5,12 @@ module Data.Lens.Internal.Wander where
 import Prelude
 
 import Data.Profunctor.Strong (Strong)
+import Data.Profunctor.Choice (Choice)
 import Data.Profunctor.Star (Star(..), runStar)
 import Data.Identity (Identity (..), runIdentity)
 
 -- | Class for profunctors that support polymorphic traversals.
-class (Strong p) <= Wander p where
+class (Strong p, Choice p) <= Wander p where
   wander
     :: forall f s t a b. (forall f. (Applicative f) => (a -> f b) -> s -> f t)
     -> p a b -> p s t

--- a/src/Data/Lens/Iso.purs
+++ b/src/Data/Lens/Iso.purs
@@ -23,7 +23,7 @@ withIso l f = case l (Exchange id id) of
 
 -- | Extracts an `Iso` from `AnIso`.
 cloneIso :: forall s t a b. AnIso s t a b -> Iso s t a b
-cloneIso l = withIso l dimap
+cloneIso l = withIso l \x y p -> iso x y p
 
 au :: forall s t a b e. AnIso s t a b -> ((b -> t) -> e -> s) -> e -> a
 au l = withIso l \sa bt f e -> sa (f bt e)

--- a/src/Data/Lens/Lens.purs
+++ b/src/Data/Lens/Lens.purs
@@ -3,12 +3,15 @@
 module Data.Lens.Lens
   ( lens
   , lens'
+  , withLens
+  , cloneLens
   ) where
 
 import Prelude
 
 import Data.Tuple
 import Data.Lens.Types
+import Data.Lens.Internal.Shop
 import Data.Profunctor
 import Data.Profunctor.Strong
 
@@ -18,3 +21,9 @@ lens' to pab = dimap to (\(Tuple b f) -> f b) (first pab)
 -- | Create a `Lens` from a getter/setter pair.
 lens :: forall s t a b. (s -> a) -> (s -> b -> t) -> Lens s t a b
 lens get set = lens' \s -> Tuple (get s) \b -> set s b
+
+withLens :: forall s t a b r. ALens s t a b -> ((s -> a) -> (s -> b -> t) -> r) -> r
+withLens l f = case l (Shop id \_ b -> b) of Shop x y -> f x y
+
+cloneLens :: forall s t a b. ALens s t a b -> Lens s t a b
+cloneLens l = withLens l \x y p -> lens x y p

--- a/src/Data/Lens/Prism.purs
+++ b/src/Data/Lens/Prism.purs
@@ -37,9 +37,7 @@ only :: forall a. (Eq a) => a -> Prism a a Unit Unit
 only x = nearly x (== x)
 
 clonePrism :: forall s t a b. APrism s t a b -> Prism s t a b
-clonePrism l = withPrism l go where
-  -- the type checker doesn't like `prism` for `go`...
-  go to fro pab = dimap fro (either id id) (right (rmap to pab))
+clonePrism l = withPrism l \x y p -> prism x y p
 
 withPrism :: forall s t a b r. APrism s t a b -> ((b -> t) -> (s -> Either t a) -> r) -> r
 withPrism l f = case l (Market id Right) of

--- a/src/Data/Lens/Traversal.purs
+++ b/src/Data/Lens/Traversal.purs
@@ -28,20 +28,20 @@ traversed = wander traverse
 traverseOf
   :: forall f s t a b. (Applicative f)
   => Optic (Star f) s t a b -> (a -> f b) -> s -> f t
-traverseOf t f = runStar (t (Star f))
+traverseOf t = runStar <<< t <<< Star
 
 -- | Sequence the foci of a `Traversal`, pulling out an `Applicative` effect.
 -- | If you do not need the result, see `sequenceOf_` for `Fold`s.
 sequenceOf
   :: forall f s t a. (Applicative f)
   => Optic (Star f) s t (f a) a -> s -> f t
-sequenceOf t = runStar $ wander id $ t (Star id)
+sequenceOf t = traverseOf t id
 
 -- | Tries to map over a `Traversal`; returns `empty`, if the traversal did
 -- | not have any new focus.
 failover
   :: forall f s t a b. (Alternative f)
   => Optic (Star (Tuple (Disj Boolean))) s t a b -> (a -> b) -> s -> f t
-failover t f s = case runStar (wander id $ t $ Star $ Tuple (Disj true) <<< f) s of
+failover t f s = case runStar (t $ Star $ Tuple (Disj true) <<< f) s of
   Tuple (Disj true) x  -> pure x
   Tuple (Disj false) _ -> empty

--- a/src/Data/Lens/Traversal.purs
+++ b/src/Data/Lens/Traversal.purs
@@ -1,23 +1,47 @@
 -- | This module defines functions for working with traversals.
 
 module Data.Lens.Traversal
-  ( traverse
+  ( traversed
   , traverseOf
+  , sequenceOf
+  , failover
   ) where
 
 import Prelude
 
 import Data.Const
 import Data.Monoid
+import Data.Monoid.Disj
+import Data.Tuple
 import Data.Lens.Types
 import Data.Profunctor.Star
-import Data.Traversable (Traversable)
+import Control.Alternative
+import Control.Plus
+import Data.Traversable (Traversable, traverse)
 import Data.Lens.Internal.Wander (wander)
 
 -- | Create a `Traversal` which traverses the elements of a `Traversable` functor.
-traverse :: forall t a b. (Traversable t) => Traversal (t a) (t b) a b
-traverse = wander
+traversed :: forall t a b. (Traversable t) => Traversal (t a) (t b) a b
+traversed = wander traverse
 
 -- | Turn a pure profunctor `Traversal` into a `lens`-like `Traversal`.
-traverseOf :: forall f s t a b. (Applicative f) => Traversal s t a b -> (a -> f b) -> s -> f t
+traverseOf
+  :: forall f s t a b. (Applicative f)
+  => Optic (Star f) s t a b -> (a -> f b) -> s -> f t
 traverseOf t f = runStar (t (Star f))
+
+-- | Sequence the foci of a `Traversal`, pulling out an `Applicative` effect.
+-- | If you do not need the result, see `sequenceOf_` for `Fold`s.
+sequenceOf
+  :: forall f s t a. (Applicative f)
+  => Optic (Star f) s t (f a) a -> s -> f t
+sequenceOf t = runStar $ wander id $ t (Star id)
+
+-- | Tries to map over a `Traversal`; returns `empty`, if the traversal did
+-- | not have any new focus.
+failover
+  :: forall f s t a b. (Alternative f)
+  => Optic (Star (Tuple (Disj Boolean))) s t a b -> (a -> b) -> s -> f t
+failover t f s = case runStar (wander id $ t $ Star $ Tuple (Disj true) <<< f) s of
+  Tuple (Disj true) x  -> pure x
+  Tuple (Disj false) _ -> empty

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -15,6 +15,7 @@ import Data.Lens.Internal.Wander
 import Data.Lens.Internal.Tagged
 import Data.Lens.Internal.Exchange
 import Data.Lens.Internal.Market
+import Data.Lens.Internal.Shop
 
 -- | A general-purpose optic.
 type Optic p s t a b = p a b -> p s t
@@ -30,6 +31,9 @@ type AnIsoP s a = AnIso s s a a
 -- | A lens.
 type Lens s t a b = forall p. (Strong p) => Optic p s t a b
 type LensP s a = Lens s s a a
+
+type ALens s t a b = Optic (Shop a b) s t a b
+type ALensP s a = ALens s s a a
 
 -- | A prism.
 type Prism s t a b = forall p. (Choice p) => Optic p s t a b

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,15 +16,12 @@ foo = lens _.foo (_ { foo = _ })
 bar :: forall a b r. Lens { bar :: a | r } { bar :: b | r } a b
 bar = lens _.bar (_ { bar = _ })
 
-_Just :: forall a b r. Prism (Maybe a) (Maybe b) a b
-_Just = prism Just (maybe (Left Nothing) Right)
-
 type Foo a = { foo :: Maybe { bar :: Array a } }
 
 doc :: Foo String
 doc = { foo: Just { bar: [ "Hello", " ", "World" ]} }
 
 bars :: forall a b. Traversal (Foo a) (Foo b) a b
-bars = foo <<< _Just <<< bar <<< traverse
+bars = foo <<< _Just <<< bar <<< traversed
 
 main = print $ view bars doc


### PR DESCRIPTION
Like the previous PR, but now the example compiles ;)

I have added `Choice` to `Wander` as a preliminary solution. Up to the point when we find out how and whether to formulate `Wander` in a different way (#1), this recovers the original semantics from Haskell's `lens`, which should be reasonable.
