### PR TITLE
Import/export tweaks

### DIFF
--- a/src/Data/Lens/Common.purs
+++ b/src/Data/Lens/Common.purs
@@ -1,16 +1,15 @@
 -- | This module defines common lenses and prisms.
 
 module Data.Lens.Common where
---------------------------------------------------------------------------------
-import Prelude
-import Data.Maybe
-import Data.Either
-import Data.Tuple
-import Data.Lens.Types
-import Data.Lens.Prism
-import Data.Lens.Lens
-import Data.Lens.Internal.Void
---------------------------------------------------------------------------------
+
+import Prelude (Unit(), unit, const, ($), (<<<))
+
+import Data.Either (Either(..), either)
+import Data.Lens.Internal.Void (Void(), absurd)
+import Data.Lens.Lens (Lens(), LensP(), lens)
+import Data.Lens.Prism (Prism(), prism)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Tuple (Tuple(..))
 
 -- | Prism for the `Nothing` constructor of `Maybe`.
 _Nothing :: forall a b. Prism (Maybe a) (Maybe b) Unit Unit

--- a/src/Data/Lens/Fold.purs
+++ b/src/Data/Lens/Fold.purs
@@ -1,36 +1,39 @@
--- | This module defines functions for working with getters.
+-- | This module defines functions for working with folds.
 
 module Data.Lens.Fold
   ( (^?), (^..)
   , preview, foldOf, foldMapOf, foldrOf, foldlOf, toListOf, firstOf, lastOf
   , maximumOf, minimumOf, allOf, anyOf, andOf, orOf, elemOf, notElemOf, sumOf
   , productOf, lengthOf, findOf, sequenceOf_, has, hasn't, replicated, filtered
+  , module ExportTypes
   ) where
 
 import Prelude
-import Data.Const
-import Data.Maybe
-import Data.List
-import Data.Either
-import Data.Tuple
-import Data.Monoid
-import Data.Maybe.First
-import Data.Maybe.Last
-import Data.Monoid.Endo
-import Data.Monoid.Conj
-import Data.Monoid.Disj
-import Data.Monoid.Dual
-import Data.Monoid.Additive
-import Data.Monoid.Multiplicative
-import Data.Functor.Contravariant
-import Data.Foldable
-import Data.Profunctor
-import Data.Profunctor.Star
-import Data.Profunctor.Choice
-import Data.Lens.Types
-import Data.Lens.Internal.Tagged
-import Data.Lens.Internal.Void
-import Control.Apply
+
+import Control.Apply ((*>))
+
+import Data.Const (Const(..), getConst)
+import Data.Either (Either(..), either)
+import Data.Foldable (Foldable, foldr)
+import Data.Functor.Contravariant (Contravariant)
+import Data.List (List(..), (:))
+import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe.First (First(..), runFirst)
+import Data.Maybe.Last (Last(..), runLast)
+import Data.Monoid.Additive (Additive(..), runAdditive)
+import Data.Monoid.Conj (Conj(..), runConj)
+import Data.Monoid.Disj (Disj(..), runDisj)
+import Data.Monoid.Dual (Dual(..), runDual)
+import Data.Monoid.Endo (Endo(..), runEndo)
+import Data.Monoid.Multiplicative (Multiplicative(..), runMultiplicative)
+import Data.Profunctor (dimap)
+import Data.Profunctor.Choice (Choice, right)
+import Data.Profunctor.Star (Star(..), runStar)
+import Data.Tuple (Tuple(..))
+
+import Data.Lens.Internal.Void (Void(), coerce)
+import Data.Lens.Types (Fold(), FoldP()) as ExportTypes
+import Data.Lens.Types (Optic(), OpticP(), Fold(), FoldP())
 
 infixl 8 ^?
 infixl 8 ^..

--- a/src/Data/Lens/Getter.purs
+++ b/src/Data/Lens/Getter.purs
@@ -3,13 +3,16 @@
 module Data.Lens.Getter
   ( (^.)
   , view, to
+  , module Data.Lens.Types
   ) where
 
-import Prelude
-import Data.Const
-import Data.Profunctor.Star
-import Data.Lens.Types
-import Data.Functor.Contravariant
+import Prelude ((<<<))
+
+import Data.Const (Const(..), getConst)
+import Data.Functor.Contravariant (Contravariant, cmap)
+import Data.Profunctor.Star (Star(..), runStar)
+
+import Data.Lens.Types (Getter(), Optic())
 
 infixl 8 ^.
 

--- a/src/Data/Lens/Internal/Exchange.purs
+++ b/src/Data/Lens/Internal/Exchange.purs
@@ -2,11 +2,9 @@
 
 module Data.Lens.Internal.Exchange where
 
-import Prelude
-import Data.Either
-import Data.Profunctor
-import qualified Data.Bifunctor as B
-import Data.Profunctor.Choice
+import Prelude (Functor, (<<<))
+
+import Data.Profunctor (Profunctor)
 
 -- | The `Exchange` profunctor characterizes an `Iso`.
 data Exchange a b s t = Exchange (s -> a) (b -> t)

--- a/src/Data/Lens/Internal/Market.purs
+++ b/src/Data/Lens/Internal/Market.purs
@@ -2,23 +2,22 @@
 
 module Data.Lens.Internal.Market where
 
-import Prelude
-import Data.Either
-import Data.Profunctor
-import qualified Data.Bifunctor as B
-import Data.Profunctor.Choice
+import Prelude (Functor, (<<<))
+
+import Data.Bifunctor as BF
+import Data.Either (Either(..), either)
+import Data.Profunctor (Profunctor)
+import Data.Profunctor.Choice (Choice)
 
 -- | The `Market` profunctor characterizes a `Prism`.
 data Market a b s t = Market (b -> t) (s -> Either t a)
 
 instance functorMarket :: Functor (Market a b s) where
-  map f (Market a b) = Market (f <<< a) (B.lmap f <<< b)
+  map f (Market a b) = Market (f <<< a) (BF.lmap f <<< b)
 
 instance profunctorMarket :: Profunctor (Market a b) where
-  dimap f g (Market a b) = Market (g <<< a) (B.lmap g <<< b <<< f)
+  dimap f g (Market a b) = Market (g <<< a) (BF.lmap g <<< b <<< f)
 
 instance choiceMarket :: Choice (Market a b) where
-  left (Market x y) = Market
-    (Left <<< x) (either (B.lmap Left <<< y) (Left <<< Right))
-  right (Market x y) = Market
-    (Right <<< x) (either (Left <<< Left) (B.lmap Right <<< y))
+  left (Market x y) = Market (Left <<< x) (either (BF.lmap Left <<< y) (Left <<< Right))
+  right (Market x y) = Market (Right <<< x) (either (Left <<< Left) (BF.lmap Right <<< y))

--- a/src/Data/Lens/Internal/Shop.purs
+++ b/src/Data/Lens/Internal/Shop.purs
@@ -2,10 +2,11 @@
 
 module Data.Lens.Internal.Shop where
 
-import Prelude
-import Data.Tuple
-import Data.Profunctor
-import Data.Profunctor.Strong
+import Prelude ((<<<))
+
+import Data.Profunctor (Profunctor)
+import Data.Profunctor.Strong (Strong)
+import Data.Tuple (Tuple(..))
 
 -- | The `Shop` profunctor characterizes a `Lens`.
 data Shop a b s t = Shop (s -> a) (s -> b -> t)

--- a/src/Data/Lens/Internal/Tagged.purs
+++ b/src/Data/Lens/Internal/Tagged.purs
@@ -2,9 +2,9 @@
 
 module Data.Lens.Internal.Tagged where
 
-import Data.Profunctor
-import Data.Profunctor.Choice
-import Data.Either
+import Data.Profunctor (Profunctor)
+import Data.Profunctor.Choice (Choice)
+import Data.Either (Either(..))
 
 newtype Tagged a b = Tagged b
 

--- a/src/Data/Lens/Internal/Void.purs
+++ b/src/Data/Lens/Internal/Void.purs
@@ -2,9 +2,11 @@
 
 module Data.Lens.Internal.Void where
 
-import Prelude
-import Data.Functor.Contravariant
-import Unsafe.Coerce
+import Prelude (Functor, (<$>))
+
+import Data.Functor.Contravariant (Contravariant, (>$<))
+
+import Unsafe.Coerce (unsafeCoerce)
 
 data Void
 

--- a/src/Data/Lens/Internal/Wander.purs
+++ b/src/Data/Lens/Internal/Wander.purs
@@ -2,12 +2,12 @@
 
 module Data.Lens.Internal.Wander where
 
-import Prelude
+import Prelude (Applicative, (<<<), ($))
 
 import Data.Profunctor.Strong (Strong)
 import Data.Profunctor.Choice (Choice)
 import Data.Profunctor.Star (Star(..), runStar)
-import Data.Identity (Identity (..), runIdentity)
+import Data.Identity (Identity(..), runIdentity)
 
 -- | Class for profunctors that support polymorphic traversals.
 class (Strong p, Choice p) <= Wander p where

--- a/src/Data/Lens/Iso.purs
+++ b/src/Data/Lens/Iso.purs
@@ -2,15 +2,15 @@
 
 module Data.Lens.Iso
   ( iso, withIso, cloneIso, au, auf, under, curried, uncurried, flipped
+  , module Data.Lens.Types
   ) where
 
-import Prelude
+import Prelude ((<<<), flip, id)
 
-import Data.Tuple
-import Data.Lens.Types
-import Data.Lens.Internal.Exchange
-import Data.Profunctor
-import Data.Profunctor.Strong
+import Data.Profunctor (Profunctor, dimap, rmap)
+import Data.Tuple (Tuple(), curry, uncurry)
+
+import Data.Lens.Types (Iso(), IsoP(), AnIso(), AnIsoP(), Exchange(..))
 
 -- | Create an `Iso` from a pair of morphisms.
 iso :: forall s t a b. (s -> a) -> (b -> t) -> Iso s t a b

--- a/src/Data/Lens/Lens.purs
+++ b/src/Data/Lens/Lens.purs
@@ -5,15 +5,17 @@ module Data.Lens.Lens
   , lens'
   , withLens
   , cloneLens
+  , module Data.Lens.Types
   ) where
 
-import Prelude
+import Prelude (id)
 
-import Data.Tuple
-import Data.Lens.Types
-import Data.Lens.Internal.Shop
-import Data.Profunctor
-import Data.Profunctor.Strong
+import Data.Profunctor (dimap)
+import Data.Profunctor.Strong (first)
+import Data.Tuple (Tuple(..))
+
+import Data.Lens.Internal.Shop (Shop(..))
+import Data.Lens.Types (Lens(), LensP(), ALens(), ALensP())
 
 lens' :: forall s t a b. (s -> Tuple a (b -> t)) -> Lens s t a b
 lens' to pab = dimap to (\(Tuple b f) -> f b) (first pab)

--- a/src/Data/Lens/Prism.purs
+++ b/src/Data/Lens/Prism.purs
@@ -1,23 +1,22 @@
--- | This module defines functions for working with lenses.
+-- | This module defines functions for working with prisms.
 
 module Data.Lens.Prism
   ( prism, prism', review, nearly, only, clonePrism, withPrism, matching
   , is, isn't
+  , module ExportTypes
   ) where
 
 import Prelude
 
-import Data.Either
-import Data.Profunctor.Star
-import Data.Const
-import Data.Maybe
-import Data.Maybe.First
-import Data.Lens.Types
-import Data.Lens.Internal.Tagged
-import Data.Lens.Internal.Market
-import Control.MonadPlus
+import Control.MonadPlus (MonadPlus, guard)
+
+import Data.Either (Either(..), either)
+import Data.Maybe (Maybe(), maybe)
 import Data.Profunctor (dimap, rmap)
-import Data.Profunctor.Choice
+import Data.Profunctor.Choice (right)
+
+import Data.Lens.Types (Prism(), PrismP(), APrism(), APrismP(), Review(), ReviewP()) as ExportTypes
+import Data.Lens.Types (Prism(), PrismP(), APrism(), APrismP(), Market(..), Review(), Tagged(..), unTagged)
 
 -- | Create a `Prism` from a constructor/pattern pair.
 prism :: forall s t a b. (b -> t) -> (s -> Either t a) -> Prism s t a b

--- a/src/Data/Lens/Setter.purs
+++ b/src/Data/Lens/Setter.purs
@@ -3,13 +3,14 @@
 module Data.Lens.Setter
   ( (%~), (.~), (+~), (-~), (*~), (//~), (||~), (&&~), (<>~), (++~), (?~)
   , over, set
+  , module Data.Lens.Types
   ) where
 
 import Prelude
-import Data.Const
-import Data.Profunctor.Star
-import Data.Lens.Types
-import Data.Maybe
+
+import Data.Maybe (Maybe(..))
+
+import Data.Lens.Types (Setter(), SetterP())
 
 infixr 4 %~
 infixr 4 .~
@@ -40,28 +41,28 @@ set l b = over l (const b)
 (.~) = set
 
 (+~) :: forall s t a. (Semiring a) => Setter s t a a -> a -> s -> t
-(+~) p = over p <<< flip (+)
+(+~) p = over p <<< add
 
 (*~) :: forall s t a. (Semiring a) => Setter s t a a -> a -> s -> t
-(*~) p = over p <<< flip (*)
+(*~) p = over p <<< flip mul
 
 (-~) :: forall s t a. (Ring a) => Setter s t a a -> a -> s -> t
-(-~) p = over p <<< flip (-)
+(-~) p = over p <<< flip sub
 
 (//~) :: forall s t a. (DivisionRing a) => Setter s t a a -> a -> s -> t
-(//~) p = over p <<< flip (/)
+(//~) p = over p <<< flip div
 
 (||~) :: forall s t a. (BooleanAlgebra a) => Setter s t a a -> a -> s -> t
-(||~) p = over p <<< flip (||)
+(||~) p = over p <<< flip disj
 
 (&&~) :: forall s t a. (BooleanAlgebra a) => Setter s t a a -> a -> s -> t
-(&&~) p = over p <<< flip (&&)
+(&&~) p = over p <<< flip conj
 
 (<>~) :: forall s t a. (Semigroup a) => Setter s t a a -> a -> s -> t
-(<>~) p = over p <<< flip (<>)
+(<>~) p = over p <<< flip append
 
 (++~) :: forall s t a. (Semigroup a) => Setter s t a a -> a -> s -> t
-(++~) p = over p <<< flip (++)
+(++~) p = over p <<< flip append
 
 (?~) :: forall s t a b. Setter s t a (Maybe b) -> b -> s -> t
 (?~) p = set p <<< Just

--- a/src/Data/Lens/Traversal.purs
+++ b/src/Data/Lens/Traversal.purs
@@ -5,20 +5,21 @@ module Data.Lens.Traversal
   , traverseOf
   , sequenceOf
   , failover
+  , module ExportTypes
   ) where
 
-import Prelude
+import Prelude (Applicative, (<<<), ($), pure, id)
 
-import Data.Const
-import Data.Monoid
-import Data.Monoid.Disj
-import Data.Tuple
-import Data.Lens.Types
-import Data.Profunctor.Star
-import Control.Alternative
-import Control.Plus
+import Control.Alternative (Alternative)
+import Control.Plus (empty)
+
+import Data.Monoid.Disj (Disj(..))
+import Data.Profunctor.Star (Star(..), runStar)
 import Data.Traversable (Traversable, traverse)
-import Data.Lens.Internal.Wander (wander)
+import Data.Tuple (Tuple(..))
+
+import Data.Lens.Types (Traversal(), TraversalP()) as ExportTypes
+import Data.Lens.Types (Traversal(), Optic(), wander)
 
 -- | Create a `Traversal` which traverses the elements of a `Traversable` functor.
 traversed :: forall t a b. (Traversable t) => Traversal (t a) (t b) a b
@@ -37,7 +38,7 @@ sequenceOf
   => Optic (Star f) s t (f a) a -> s -> f t
 sequenceOf t = traverseOf t id
 
--- | Tries to map over a `Traversal`; returns `empty`, if the traversal did
+-- | Tries to map over a `Traversal`; returns `empty` if the traversal did
 -- | not have any new focus.
 failover
   :: forall f s t a b. (Alternative f)

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -1,23 +1,28 @@
--- | This module defines functions for working with lenses.
+-- | This module defines types for working with lenses.
 
-module Data.Lens.Types where
+module Data.Lens.Types
+  ( module Data.Lens.Types
+  , module Data.Lens.Internal.Exchange
+  , module Data.Lens.Internal.Market
+  , module Data.Lens.Internal.Shop
+  , module Data.Lens.Internal.Tagged
+  , module Data.Lens.Internal.Wander
+  ) where
 
-import Prelude
+import Data.Const (Const())
+import Data.Maybe.First (First())
+import Data.Profunctor (Profunctor)
+import Data.Profunctor.Choice (Choice)
+import Data.Profunctor.Star (Star())
+import Data.Profunctor.Strong (Strong)
 
-import Data.Profunctor
-import Data.Profunctor.Star
-import Data.Profunctor.Strong
-import Data.Profunctor.Choice
-import Data.Maybe.First
-import Data.Const
+import Data.Lens.Internal.Exchange (Exchange(..))
+import Data.Lens.Internal.Market (Market(..))
+import Data.Lens.Internal.Shop (Shop(..))
+import Data.Lens.Internal.Tagged (Tagged(..), unTagged)
+import Data.Lens.Internal.Wander (Wander, wander)
 
-import Data.Lens.Internal.Wander
-import Data.Lens.Internal.Tagged
-import Data.Lens.Internal.Exchange
-import Data.Lens.Internal.Market
-import Data.Lens.Internal.Shop
-
--- | A general-purpose optic.
+-- | A general-purpose Data.Lens.
 type Optic p s t a b = p a b -> p s t
 type OpticP p s a = Optic p s s a a
 


### PR DESCRIPTION
- Qualified imports
- Individual modules re-export pertinent types (like `Prism`, `PrismP`, etc from `Data.Lens.Prism`)
- Fixed a few typos in the module descriptions
