### PR TITLE
Add Coproduct prisms, split up Data.Lens.Common

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,5 @@
 {
   "name": "purescript-profunctor-lenses",
-  "version": "1.0.0",
-  "moduleType": [
-    "node"
-  ],
   "ignore": [
     "**/.*",
     "node_modules",
@@ -12,13 +8,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/paf31/purescript-profunctor-lenses.git"
+    "url": "git://github.com/purescript-contrib/purescript-profunctor-lenses.git"
   },
   "devDependencies": {
     "purescript-console": "^0.1.0"
   },
   "dependencies": {
     "purescript-const": "~0.5.0",
+    "purescript-coproducts": "~0.4.0",
+    "purescript-functors": "~0.1.0",
     "purescript-identity": "~0.4.0",
     "purescript-lists": "~0.7.0",
     "purescript-maps": "~0.5.2",

--- a/src/Data/Lens/Common.purs
+++ b/src/Data/Lens/Common.purs
@@ -1,44 +1,15 @@
 -- | This module defines common lenses and prisms.
 
-module Data.Lens.Common where
+module Data.Lens.Common
+  ( module Data.Lens.Lens.Tuple
+  , module Data.Lens.Lens.Unit
+  , module Data.Lens.Lens.Void
+  , module Data.Lens.Prism.Either
+  , module Data.Lens.Prism.Maybe
+  ) where
 
-import Prelude (Unit(), unit, const, ($), (<<<))
-
-import Data.Either (Either(..), either)
-import Data.Lens.Internal.Void (Void(), absurd)
-import Data.Lens.Lens (Lens(), LensP(), lens)
-import Data.Lens.Prism (Prism(), prism)
-import Data.Maybe (Maybe(..), maybe)
-import Data.Tuple (Tuple(..))
-
--- | Prism for the `Nothing` constructor of `Maybe`.
-_Nothing :: forall a b. Prism (Maybe a) (Maybe b) Unit Unit
-_Nothing = prism (const Nothing) $ maybe (Right unit) (const $ Left Nothing)
-
--- | Prism for the `Just` constructor of `Maybe`.
-_Just :: forall a b. Prism (Maybe a) (Maybe b) a b
-_Just = prism Just $ maybe (Left Nothing) Right
-
--- | Prism for the `Left` constructor of `Either`.
-_Left :: forall a b c. Prism (Either a c) (Either b c) a b
-_Left = prism Left $ either Right (Left <<< Right)
-
--- | Prism for the `Right` constructor of `Either`.
-_Right :: forall a b c. Prism (Either c a) (Either c b) a b
-_Right = prism Right $ either (Left <<< Left) Right
-
--- | Lens for the first component of a `Tuple`.
-_1 :: forall a b c. Lens (Tuple a c) (Tuple b c) a b
-_1 = lens (\(Tuple a _) -> a) \(Tuple _ c) b -> Tuple b c
-
--- | Lens for the second component of a `Tuple`.
-_2 :: forall a b c. Lens (Tuple c a) (Tuple c b) a b
-_2 = lens (\(Tuple _ a) -> a) \(Tuple c _) b -> Tuple c b
-
--- | There is a `Unit` in everything.
-united :: forall a. LensP a Unit
-united = lens (const unit) const
-
--- | There is everything in `Void`.
-devoid :: forall a. LensP Void a
-devoid = lens absurd const
+import Data.Lens.Lens.Tuple
+import Data.Lens.Lens.Unit
+import Data.Lens.Lens.Void
+import Data.Lens.Prism.Either
+import Data.Lens.Prism.Maybe

--- a/src/Data/Lens/Iso/Coproduct.purs
+++ b/src/Data/Lens/Iso/Coproduct.purs
@@ -1,0 +1,9 @@
+module Data.Lens.Iso.Coproduct where
+
+import Data.Functor.Coproduct (Coproduct(..), runCoproduct)
+import Data.Either (Either())
+
+import Data.Lens.Iso (Iso(), iso)
+
+_Coproduct :: forall f g h i a b. Iso (Coproduct f g a) (Coproduct h i b) (Either (f a) (g a)) (Either (h b) (i b))
+_Coproduct = iso runCoproduct Coproduct

--- a/src/Data/Lens/Iso/Product.purs
+++ b/src/Data/Lens/Iso/Product.purs
@@ -1,0 +1,9 @@
+module Data.Lens.Iso.Product where
+
+import Data.Functor.Product (Product(..), runProduct)
+import Data.Tuple (Tuple())
+
+import Data.Lens.Iso (Iso(), iso)
+
+_Product :: forall f g h i a b. Iso (Product f g a) (Product h i b) (Tuple (f a) (g a)) (Tuple (h b) (i b))
+_Product = iso runProduct Product

--- a/src/Data/Lens/Lens/Product.purs
+++ b/src/Data/Lens/Lens/Product.purs
@@ -1,0 +1,14 @@
+module Data.Lens.Lens.Product where
+
+import Data.Functor.Product (Product(..))
+import Data.Tuple (Tuple(..))
+
+import Data.Lens.Lens (Lens(), lens)
+
+-- | Lens for the first component of a `Product`.
+_1 :: forall f g h a. Lens (Product f g a) (Product h g a) (f a) (h a)
+_1 = lens (\(Product (Tuple a _)) -> a) \(Product (Tuple _ c)) b -> Product (Tuple b c)
+
+-- | Lens for the second component of a `Product`.
+_2 :: forall f g h a. Lens (Product f g a) (Product f h a) (g a) (h a)
+_2 = lens (\(Product (Tuple _ a)) -> a) \(Product (Tuple c _)) b -> Product (Tuple c b)

--- a/src/Data/Lens/Lens/Product.purs
+++ b/src/Data/Lens/Lens/Product.purs
@@ -1,14 +1,17 @@
 module Data.Lens.Lens.Product where
 
-import Data.Functor.Product (Product(..))
-import Data.Tuple (Tuple(..))
+import Prelude ((<<<))
 
-import Data.Lens.Lens (Lens(), lens)
+import Data.Functor.Product (Product())
 
--- | Lens for the first component of a `Product`.
+import Data.Lens.Iso.Product (_Product)
+import Data.Lens.Lens (Lens())
+import Data.Lens.Lens.Tuple as T
+
+-- | Lens for the `left` of a `Product`.
 _1 :: forall f g h a. Lens (Product f g a) (Product h g a) (f a) (h a)
-_1 = lens (\(Product (Tuple a _)) -> a) \(Product (Tuple _ c)) b -> Product (Tuple b c)
+_1 = _Product <<< T._1
 
--- | Lens for the second component of a `Product`.
+-- | Lens for the `right` of a `Product`.
 _2 :: forall f g h a. Lens (Product f g a) (Product f h a) (g a) (h a)
-_2 = lens (\(Product (Tuple _ a)) -> a) \(Product (Tuple c _)) b -> Product (Tuple c b)
+_2 = _Product <<< T._2

--- a/src/Data/Lens/Lens/Tuple.purs
+++ b/src/Data/Lens/Lens/Tuple.purs
@@ -1,0 +1,13 @@
+module Data.Lens.Lens.Tuple where
+
+import Data.Tuple (Tuple(..))
+
+import Data.Lens.Lens (Lens(), lens)
+
+-- | Lens for the first component of a `Tuple`.
+_1 :: forall a b c. Lens (Tuple a c) (Tuple b c) a b
+_1 = lens (\(Tuple a _) -> a) \(Tuple _ c) b -> Tuple b c
+
+-- | Lens for the second component of a `Tuple`.
+_2 :: forall a b c. Lens (Tuple c a) (Tuple c b) a b
+_2 = lens (\(Tuple _ a) -> a) \(Tuple c _) b -> Tuple c b

--- a/src/Data/Lens/Lens/Unit.purs
+++ b/src/Data/Lens/Lens/Unit.purs
@@ -1,0 +1,9 @@
+module Data.Lens.Lens.Unit where
+
+import Prelude
+
+import Data.Lens.Lens (LensP(), lens)
+
+-- | There is a `Unit` in everything.
+united :: forall a. LensP a Unit
+united = lens (const unit) const

--- a/src/Data/Lens/Lens/Void.purs
+++ b/src/Data/Lens/Lens/Void.purs
@@ -1,0 +1,11 @@
+module Data.Lens.Lens.Void where
+
+import Prelude (const)
+
+import Data.Lens.Internal.Void (Void(), absurd)
+
+import Data.Lens.Lens (LensP(), lens)
+
+-- | There is everything in `Void`.
+devoid :: forall a. LensP Void a
+devoid = lens absurd const

--- a/src/Data/Lens/Prism/Coproduct.purs
+++ b/src/Data/Lens/Prism/Coproduct.purs
@@ -1,16 +1,17 @@
 module Data.Lens.Prism.Coproduct where
 
-import Prelude
+import Prelude ((<<<))
 
-import Data.Either (Either(..))
-import Data.Functor.Coproduct (Coproduct(), coproduct, left, right)
+import Data.Functor.Coproduct (Coproduct())
 
-import Data.Lens.Prism (Prism(), prism)
+import Data.Lens.Iso.Coproduct (_Coproduct)
+import Data.Lens.Prism (Prism())
+import Data.Lens.Prism.Either as E
 
 -- | Prism for the `left` of a `Coproduct`.
 _Left :: forall f g h a. Prism (Coproduct f g a) (Coproduct h g a) (f a) (h a)
-_Left = prism left $ coproduct Right (Left <<< right)
+_Left = _Coproduct <<< E._Left
 
 -- | Prism for the `right` of a `Coproduct`.
 _Right :: forall f g h a. Prism (Coproduct f g a) (Coproduct f h a) (g a) (h a)
-_Right = prism right $ coproduct (Left <<< left) Right
+_Right = _Coproduct <<< E._Right

--- a/src/Data/Lens/Prism/Coproduct.purs
+++ b/src/Data/Lens/Prism/Coproduct.purs
@@ -1,0 +1,16 @@
+module Data.Lens.Prism.Coproduct where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Functor.Coproduct (Coproduct(), coproduct, left, right)
+
+import Data.Lens.Prism (Prism(), prism)
+
+-- | Prism for the `left` of a `Coproduct`.
+_Left :: forall f g h a. Prism (Coproduct f g a) (Coproduct h g a) (f a) (h a)
+_Left = prism left $ coproduct Right (Left <<< right)
+
+-- | Prism for the `right` of a `Coproduct`.
+_Right :: forall f g h a. Prism (Coproduct f g a) (Coproduct f h a) (g a) (h a)
+_Right = prism right $ coproduct (Left <<< left) Right

--- a/src/Data/Lens/Prism/Either.purs
+++ b/src/Data/Lens/Prism/Either.purs
@@ -1,0 +1,15 @@
+module Data.Lens.Prism.Either where
+
+import Prelude
+
+import Data.Either (Either(..), either)
+
+import Data.Lens.Prism (Prism(), prism)
+
+-- | Prism for the `Left` constructor of `Either`.
+_Left :: forall a b c. Prism (Either a c) (Either b c) a b
+_Left = prism Left $ either Right (Left <<< Right)
+
+-- | Prism for the `Right` constructor of `Either`.
+_Right :: forall a b c. Prism (Either c a) (Either c b) a b
+_Right = prism Right $ either (Left <<< Left) Right

--- a/src/Data/Lens/Prism/Maybe.purs
+++ b/src/Data/Lens/Prism/Maybe.purs
@@ -1,0 +1,16 @@
+module Data.Lens.Prism.Maybe where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), maybe)
+
+import Data.Lens.Prism (Prism(), prism)
+
+-- | Prism for the `Nothing` constructor of `Maybe`.
+_Nothing :: forall a b. Prism (Maybe a) (Maybe b) Unit Unit
+_Nothing = prism (const Nothing) $ maybe (Right unit) (const $ Left Nothing)
+
+-- | Prism for the `Just` constructor of `Maybe`.
+_Just :: forall a b. Prism (Maybe a) (Maybe b) a b
+_Just = prism Just $ maybe (Left Nothing) Right


### PR DESCRIPTION
I didn't include the `Coproduct` prism in `Common` as, well, I'm not sure they're all that common.

Also, I named the prisms `_Left` and `_Right` which conflicts with the `Either` prisms, but I think I'd prefer to have them that way and then import qualified then disambiguate than calling them `_CoproductLeft`, `_CLeft` or something. Thoughts?

Even though I shuffled things around a bit here I wouldn't consider this a breaking change either, as `Data.Lens.Common` exports all the same things it used to.
