### PR TITLE
Indexed optics.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "purescript-profunctor": "~0.3.0",
     "purescript-sets": "~0.5.1",
     "purescript-unsafe-coerce": "~0.1.0",
-    "purescript-transformers": "~0.8.1"
+    "purescript-transformers": "~0.8.1",
+    "purescript-functor-compose": "~0.0.1"
   }
 }

--- a/docs/Data/Lens/Fold.md
+++ b/docs/Data/Lens/Fold.md
@@ -223,4 +223,60 @@ replicated :: forall a b t f. (Applicative f, Contravariant f) => Int -> Optic (
 
 Replicates the elements of a fold.
 
+#### `ifoldMapOf`
+
+``` purescript
+ifoldMapOf :: forall r i s t a b. IndexedFold r i s t a b -> (i -> a -> r) -> s -> r
+```
+
+Fold map over an `IndexedFold`.
+
+#### `ifoldrOf`
+
+``` purescript
+ifoldrOf :: forall i s t a b r. IndexedFold (Endo r) i s t a b -> (i -> a -> r -> r) -> r -> s -> r
+```
+
+Right fold over an `IndexedFold`.
+
+#### `ifoldlOf`
+
+``` purescript
+ifoldlOf :: forall i s t a b r. IndexedFold (Dual (Endo r)) i s t a b -> (i -> r -> a -> r) -> r -> s -> r
+```
+
+Left fold over an `IndexedFold`.
+
+#### `iallOf`
+
+``` purescript
+iallOf :: forall i s t a b r. (BooleanAlgebra r) => IndexedFold (Conj r) i s t a b -> (i -> a -> r) -> s -> r
+```
+
+Whether all foci of an `IndexedFold` satisfy a predicate.
+
+#### `ianyOf`
+
+``` purescript
+ianyOf :: forall i s t a b r. (BooleanAlgebra r) => IndexedFold (Disj r) i s t a b -> (i -> a -> r) -> s -> r
+```
+
+Whether any focus of an `IndexedFold` satisfies a predicate.
+
+#### `itoListOf`
+
+``` purescript
+itoListOf :: forall i s t a b. IndexedFold (Endo (List (Tuple i a))) i s t a b -> s -> List (Tuple i a)
+```
+
+Collects the foci of an `IndexedFold` into a list.
+
+#### `itraverseOf_`
+
+``` purescript
+itraverseOf_ :: forall i f s t a b r. (Applicative f) => IndexedFold (Endo (f Unit)) i s t a b -> (i -> a -> f r) -> s -> f Unit
+```
+
+Traverse the foci of an `IndexedFold`, discarding the results.
+
 

--- a/docs/Data/Lens/Getter.md
+++ b/docs/Data/Lens/Getter.md
@@ -10,6 +10,14 @@ view :: forall s t a b. Getter s t a b -> s -> a
 
 View the focus of a `Getter`.
 
+#### `iview`
+
+``` purescript
+iview :: forall i s t a b. IndexedFold (Tuple i a) i s t a b -> s -> Tuple i a
+```
+
+View the focus of a `Getter` and its index.
+
 #### `(^.)`
 
 ``` purescript
@@ -27,5 +35,21 @@ to :: forall s a f. (Contravariant f) => (s -> a) -> Optic (Star f) s s a a
 ```
 
 Convert a function into a getter.
+
+#### `use`
+
+``` purescript
+use :: forall s t a b m. (MonadState s m) => Getter s t a b -> m a
+```
+
+View the focus of a `Getter` in the state of a monad.
+
+#### `iuse`
+
+``` purescript
+iuse :: forall i s t a b m. (MonadState s m) => IndexedFold (Tuple i a) i s t a b -> m (Tuple i a)
+```
+
+View the focus of a `Getter` and its index in the state of a monad.
 
 

--- a/docs/Data/Lens/Indexed.md
+++ b/docs/Data/Lens/Indexed.md
@@ -1,0 +1,27 @@
+## Module Data.Lens.Indexed
+
+#### `unIndex`
+
+``` purescript
+unIndex :: forall p i s t a b. (Profunctor p) => IndexedOptic p i s t a b -> Optic p s t a b
+```
+
+Converts an `IndexedOptic` to an `Optic` by forgetting indices.
+
+#### `iwander`
+
+``` purescript
+iwander :: forall p i s t a b. (Wander p) => (forall f. (Applicative f) => (i -> a -> f b) -> s -> f t) -> Indexed p i a b -> p s t
+```
+
+Converts a `lens`-like indexed traversal to an `IndexedTraversal`.
+
+#### `positions`
+
+``` purescript
+positions :: forall p s t a b. (Wander p) => Traversal s t a b -> IndexedOptic p Int s t a b
+```
+
+Converts a `Traversal` to an `IndexedTraversal` by using the integer positions as indices.
+
+

--- a/docs/Data/Lens/Internal/Focusing.md
+++ b/docs/Data/Lens/Internal/Focusing.md
@@ -1,0 +1,27 @@
+## Module Data.Lens.Internal.Focusing
+
+This module defines the `Focusing` functor
+
+#### `Focusing`
+
+``` purescript
+newtype Focusing m s a
+  = Focusing (m (Tuple s a))
+```
+
+The functor used to zoom into `StateT`.
+
+##### Instances
+``` purescript
+instance focusingFunctor :: (Functor m) => Functor (Focusing m s)
+instance focusingApply :: (Apply m, Semigroup s) => Apply (Focusing m s)
+instance focusingApplicative :: (Applicative m, Monoid s) => Applicative (Focusing m s)
+```
+
+#### `runFocusing`
+
+``` purescript
+runFocusing :: forall m s a. Focusing m s a -> m (Tuple s a)
+```
+
+

--- a/docs/Data/Lens/Internal/Forget.md
+++ b/docs/Data/Lens/Internal/Forget.md
@@ -1,0 +1,33 @@
+## Module Data.Lens.Internal.Forget
+
+#### `Forget`
+
+``` purescript
+newtype Forget r a b
+  = Forget (a -> r)
+```
+
+Profunctor that forgets the `b` value and returns (and accumulates) a
+value of type `r`.
+
+`Forget r` is isomorphic to `Star (Const r)`, but can be given a `Cochoice`
+instance.
+
+##### Instances
+``` purescript
+instance profunctorForget :: Profunctor (Forget r)
+instance choiceForget :: (Monoid r) => Choice (Forget r)
+instance strongForget :: Strong (Forget r)
+instance cochoiceForget :: Cochoice (Forget r)
+instance wanderForget :: (Monoid r) => Wander (Forget r)
+```
+
+#### `runForget`
+
+``` purescript
+runForget :: forall r a b. Forget r a b -> a -> r
+```
+
+Unwrap a value of type `Forget`.
+
+

--- a/docs/Data/Lens/Internal/Indexed.md
+++ b/docs/Data/Lens/Internal/Indexed.md
@@ -1,0 +1,29 @@
+## Module Data.Lens.Internal.Indexed
+
+This module defines the `Indexed` profunctor.
+
+#### `Indexed`
+
+``` purescript
+newtype Indexed p i s t
+  = Indexed (p (Tuple i s) t)
+```
+
+Profunctor used for `IndexedOptic`s.
+
+##### Instances
+``` purescript
+instance indexedProfunctor :: (Profunctor p) => Profunctor (Indexed p i)
+instance indexedStrong :: (Strong p) => Strong (Indexed p i)
+instance indexedChoice :: (Choice p) => Choice (Indexed p i)
+```
+
+#### `fromIndexed`
+
+``` purescript
+fromIndexed :: forall p i s t. Indexed p i s t -> p (Tuple i s) t
+```
+
+Unwrap a value of type `Indexed`.
+
+

--- a/docs/Data/Lens/Internal/Re.md
+++ b/docs/Data/Lens/Internal/Re.md
@@ -1,0 +1,27 @@
+## Module Data.Lens.Internal.Re
+
+This module defines the `Re` profunctor
+
+#### `Re`
+
+``` purescript
+newtype Re p s t a b
+  = Re (p b a -> p t s)
+```
+
+##### Instances
+``` purescript
+instance profunctorRe :: (Profunctor p) => Profunctor (Re p s t)
+instance choiceRe :: (Choice p) => Cochoice (Re p s t)
+instance cochoiceRe :: (Cochoice p) => Choice (Re p s t)
+instance strongRe :: (Strong p) => Costrong (Re p s t)
+instance costrongRe :: (Costrong p) => Strong (Re p s t)
+```
+
+#### `runRe`
+
+``` purescript
+runRe :: forall p s t a b. Re p s t a b -> p b a -> p t s
+```
+
+

--- a/docs/Data/Lens/Internal/Tagged.md
+++ b/docs/Data/Lens/Internal/Tagged.md
@@ -13,6 +13,7 @@ newtype Tagged a b
 ``` purescript
 instance taggedProfunctor :: Profunctor Tagged
 instance taggedChoice :: Choice Tagged
+instance taggedCostrong :: Costrong Tagged
 ```
 
 #### `unTagged`

--- a/docs/Data/Lens/Iso.md
+++ b/docs/Data/Lens/Iso.md
@@ -26,6 +26,14 @@ cloneIso :: forall s t a b. AnIso s t a b -> Iso s t a b
 
 Extracts an `Iso` from `AnIso`.
 
+#### `re`
+
+``` purescript
+re :: forall p s t a b. Optic (Re p a b) s t a b -> Optic p b a t s
+```
+
+Reverses an optic.
+
 #### `au`
 
 ``` purescript

--- a/docs/Data/Lens/Setter.md
+++ b/docs/Data/Lens/Setter.md
@@ -110,4 +110,96 @@ _right-associative / precedence 4_
 
 _right-associative / precedence 4_
 
+#### `(.=)`
+
+``` purescript
+(.=) :: forall s a b m. (MonadState s m) => Setter s s a b -> b -> m Unit
+```
+
+_non-associative / precedence 4_
+
+Synonym for `assign`
+
+#### `(%=)`
+
+``` purescript
+(%=) :: forall s a b m. (MonadState s m) => Setter s s a b -> (a -> b) -> m Unit
+```
+
+_non-associative / precedence 4_
+
+Synonym for `modifying`
+
+#### `(+=)`
+
+``` purescript
+(+=) :: forall s a m. (MonadState s m, Semiring a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(*=)`
+
+``` purescript
+(*=) :: forall s a m. (MonadState s m, Semiring a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(-=)`
+
+``` purescript
+(-=) :: forall s a m. (MonadState s m, Ring a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(//=)`
+
+``` purescript
+(//=) :: forall s a m. (MonadState s m, DivisionRing a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(||=)`
+
+``` purescript
+(||=) :: forall s a m. (MonadState s m, BooleanAlgebra a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(&&=)`
+
+``` purescript
+(&&=) :: forall s a m. (MonadState s m, BooleanAlgebra a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(<>=)`
+
+``` purescript
+(<>=) :: forall s a m. (MonadState s m, Semigroup a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(++=)`
+
+``` purescript
+(++=) :: forall s a m. (MonadState s m, Semigroup a) => SetterP s a -> a -> m Unit
+```
+
+_non-associative / precedence 4_
+
+#### `(?=)`
+
+``` purescript
+(?=) :: forall s a b m. (MonadState s m) => Setter s s a (Maybe b) -> b -> m Unit
+```
+
+_non-associative / precedence 4_
+
 

--- a/docs/Data/Lens/Traversal.md
+++ b/docs/Data/Lens/Traversal.md
@@ -36,4 +36,12 @@ failover :: forall f s t a b. (Alternative f) => Optic (Star (Tuple (Disj Boolea
 Tries to map over a `Traversal`; returns `empty` if the traversal did
 not have any new focus.
 
+#### `elementsOf`
+
+``` purescript
+elementsOf :: forall p i s t a. (Wander p) => IndexedTraversal i s t a a -> (i -> Boolean) -> IndexedOptic p i s t a a
+```
+
+Traverse elements of an `IndexedTraversal` whose index satisfy a predicate.
+
 

--- a/docs/Data/Lens/Types.md
+++ b/docs/Data/Lens/Types.md
@@ -153,7 +153,7 @@ type ReviewP s a = Review s s a a
 #### `Fold`
 
 ``` purescript
-type Fold r s t a b = Optic (Star (Const r)) s t a b
+type Fold r s t a b = Optic (Forget r) s t a b
 ```
 
 A fold.
@@ -162,6 +162,76 @@ A fold.
 
 ``` purescript
 type FoldP r s a = Fold r s s a a
+```
+
+#### `IndexedOptic`
+
+``` purescript
+type IndexedOptic p i s t a b = Indexed p i a b -> p s t
+```
+
+An indexed optic.
+
+#### `IndexedOpticP`
+
+``` purescript
+type IndexedOpticP p i s a = IndexedOptic p i s s a a
+```
+
+#### `IndexedTraversal`
+
+``` purescript
+type IndexedTraversal i s t a b = forall p. (Wander p) => IndexedOptic p i s t a b
+```
+
+An indexed traversal.
+
+#### `IndexedTraversalP`
+
+``` purescript
+type IndexedTraversalP i s a = IndexedTraversal i s s a a
+```
+
+#### `IndexedFold`
+
+``` purescript
+type IndexedFold r i s t a b = IndexedOptic (Forget r) i s t a b
+```
+
+An indexed fold.
+
+#### `IndexedFoldP`
+
+``` purescript
+type IndexedFoldP r i s a = IndexedFold r i s s a a
+```
+
+#### `IndexedGetter`
+
+``` purescript
+type IndexedGetter i s t a b = IndexedFold a i s t a b
+```
+
+An indexed getter.
+
+#### `IndexedGetterP`
+
+``` purescript
+type IndexedGetterP i s a = IndexedGetter i s s a a
+```
+
+#### `IndexedSetter`
+
+``` purescript
+type IndexedSetter i s t a b = IndexedOptic Function i s t a b
+```
+
+An indexed setter.
+
+#### `IndexedSetterP`
+
+``` purescript
+type IndexedSetterP i s a = IndexedSetter i s s a a
 ```
 
 

--- a/docs/Data/Lens/Zoom.md
+++ b/docs/Data/Lens/Zoom.md
@@ -1,0 +1,13 @@
+## Module Data.Lens.Zoom
+
+This module defines functions for zooming in a state monad.
+
+#### `zoom`
+
+``` purescript
+zoom :: forall a s r m. OpticP (Star (Focusing m r)) s a -> StateT a m r -> StateT s m r
+```
+
+Zooms into a substate in a `StateT` transformer.
+
+

--- a/src/Data/Lens/Getter.purs
+++ b/src/Data/Lens/Getter.purs
@@ -2,25 +2,32 @@
 
 module Data.Lens.Getter
   ( (^.)
-  , view, to, use
+  , view, to, use, iview, iuse
   , module Data.Lens.Types
   ) where
 
-import Prelude (id, (<<<))
+import Prelude (id, (<<<), ($))
 
 import Data.Const (Const(..), getConst)
 import Data.Functor.Contravariant (Contravariant, cmap)
 import Data.Profunctor.Star (Star(..), runStar)
+import Data.Tuple (Tuple (..))
 import Control.Monad.State.Class (MonadState, gets)
 
 import Data.Lens.Internal.Forget (Forget (..), runForget)
 import Data.Lens.Types (Getter(), Optic())
+import Data.Lens.Types (IndexedGetter(), Indexed (..))
+import Data.Lens.Types (IndexedFold())
 
 infixl 8 ^.
 
 -- | View the focus of a `Getter`.
 view :: forall s t a b. Getter s t a b -> s -> a
 view l = runForget (l (Forget id))
+
+-- | View the focus of a `Getter` and its index.
+iview :: forall i s t a b. IndexedFold (Tuple i a) i s t a b -> s -> Tuple i a
+iview l = runForget (l (Indexed $ Forget id))
 
 -- | Synonym for `view`, flipped.
 (^.) :: forall s t a b. s -> Getter s t a b -> a
@@ -30,5 +37,12 @@ view l = runForget (l (Forget id))
 to :: forall s a f. (Contravariant f) => (s -> a) -> Optic (Star f) s s a a
 to f p = Star (cmap f <<< runStar p <<< f)
 
+-- | View the focus of a `Getter` in the state of a monad.
 use :: forall s t a b m. (MonadState s m) => Getter s t a b -> m a
 use p = gets (^. p)
+
+-- | View the focus of a `Getter` and its index in the state of a monad.
+iuse
+  :: forall i s t a b m. (MonadState s m)
+  => IndexedFold (Tuple i a) i s t a b -> m (Tuple i a)
+iuse p = gets (iview p)

--- a/src/Data/Lens/Indexed.purs
+++ b/src/Data/Lens/Indexed.purs
@@ -1,0 +1,38 @@
+module Data.Lens.Indexed where
+
+import Prelude
+
+import Control.Monad.State
+import Control.Apply
+
+import Data.Profunctor
+import Data.Profunctor.Star
+import Data.Profunctor.Strong
+import Data.Profunctor.Choice
+import Data.Functor.Compose
+import Data.Tuple
+import Data.Either
+
+import Data.Lens.Types
+import Data.Lens.Internal.Indexed
+import Data.Lens.Internal.Wander
+
+-- | Converts an `IndexedOptic` to an `Optic` by forgetting indices.
+unIndex
+  :: forall p i s t a b. (Profunctor p)
+  => IndexedOptic p i s t a b -> Optic p s t a b
+unIndex l = l <<< Indexed <<< dimap snd id
+
+-- | Converts a `lens`-like indexed traversal to an `IndexedTraversal`.
+iwander
+  :: forall p i s t a b. (Wander p)
+  => (forall f. (Applicative f) => (i -> a -> f b) -> s -> f t)
+  -> Indexed p i a b -> p s t
+iwander itr = wander (\f s -> itr (curry f) s) <<< fromIndexed
+
+-- | Converts a `Traversal` to an `IndexedTraversal` by using the integer positions as indices.
+positions
+  :: forall p s t a b. (Wander p)
+  => Traversal s t a b -> IndexedOptic p Int s t a b
+positions tr = iwander \f s -> flip evalState 0 $ decompose $ flip runStar s $
+  tr $ Star \a -> Compose $ (f <$> get <*> pure a) <* modify (+1)

--- a/src/Data/Lens/Internal/Indexed.purs
+++ b/src/Data/Lens/Internal/Indexed.purs
@@ -1,0 +1,28 @@
+-- | This module defines the `Indexed` profunctor.
+module Data.Lens.Internal.Indexed where
+
+import Prelude
+
+import Data.Profunctor
+import Data.Profunctor.Strong
+import Data.Profunctor.Choice
+import Data.Tuple
+import Data.Either
+
+-- | Profunctor used for `IndexedOptic`s.
+newtype Indexed p i s t = Indexed (p (Tuple i s) t)
+
+-- | Unwrap a value of type `Indexed`.
+fromIndexed :: forall p i s t. Indexed p i s t -> p (Tuple i s) t
+fromIndexed (Indexed p) = p
+
+instance indexedProfunctor :: (Profunctor p) => Profunctor (Indexed p i) where
+  dimap f g = Indexed <<< dimap (second f) g <<< fromIndexed
+
+instance indexedStrong :: (Strong p) => Strong (Indexed p i) where
+  first = Indexed <<< dimap (\(Tuple i (Tuple a c)) -> (Tuple (Tuple i a) c)) id <<< first <<< fromIndexed
+  second = Indexed <<< dimap (\(Tuple i (Tuple c a)) -> (Tuple c (Tuple i a))) id <<< second <<< fromIndexed
+
+instance indexedChoice :: (Choice p) => Choice (Indexed p i) where
+  left (Indexed p) = Indexed (dimap (\(Tuple i ac) -> either (Left <<< Tuple i) Right ac) id $ left p)
+  right (Indexed p) = Indexed (dimap (\(Tuple i ac) -> either Left (Right <<< Tuple i) ac) id $ right p)

--- a/src/Data/Lens/Setter.purs
+++ b/src/Data/Lens/Setter.purs
@@ -11,8 +11,10 @@ import Prelude
 
 import Control.Monad.State.Class (MonadState, modify)
 import Data.Maybe (Maybe(..))
+import Data.Tuple (uncurry)
 
 import Data.Lens.Types (Setter(), SetterP())
+import Data.Lens.Types (IndexedSetter(), Indexed(..))
 
 infixr 4 %~
 infixr 4 .~
@@ -45,6 +47,10 @@ over l = l
 -- | Synonym for `over`.
 (%~) :: forall s t a b. Setter s t a b -> (a -> b) -> s -> t
 (%~) = over
+
+-- | Apply a function to the foci of a `Setter` that may vary with the index.
+iover :: forall i s t a b. IndexedSetter i s t a b -> (i -> a -> b) -> s -> t
+iover l f = l (Indexed $ uncurry f)
 
 -- | Set the foci of a `Setter` to a constant value.
 set :: forall s t a b. Setter s t a b -> b -> s -> t

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -9,6 +9,7 @@ module Data.Lens.Types
   , module Data.Lens.Internal.Forget
   , module Data.Lens.Internal.Wander
   , module Data.Lens.Internal.Re
+  , module Data.Lens.Internal.Indexed
   ) where
 
 import Data.Const (Const())
@@ -25,6 +26,7 @@ import Data.Lens.Internal.Tagged (Tagged(..), unTagged)
 import Data.Lens.Internal.Forget (Forget(..), runForget)
 import Data.Lens.Internal.Wander (Wander, wander)
 import Data.Lens.Internal.Re (Re(..), runRe)
+import Data.Lens.Internal.Indexed (Indexed (..), fromIndexed)
 
 -- | A general-purpose Data.Lens.
 type Optic p s t a b = p a b -> p s t
@@ -70,3 +72,23 @@ type ReviewP s a = Review s s a a
 -- | A fold.
 type Fold r s t a b = Optic (Forget r) s t a b
 type FoldP r s a = Fold r s s a a
+
+-- | An indexed optic.
+type IndexedOptic p i s t a b = Indexed p i a b -> p s t
+type IndexedOpticP p i s a = IndexedOptic p i s s a a
+
+-- | An indexed traversal.
+type IndexedTraversal i s t a b = forall p. (Wander p) => IndexedOptic p i s t a b
+type IndexedTraversalP i s a = IndexedTraversal i s s a a
+
+-- | An indexed fold.
+type IndexedFold r i s t a b = IndexedOptic (Forget r) i s t a b
+type IndexedFoldP r i s a = IndexedFold r i s s a a
+
+-- | An indexed getter.
+type IndexedGetter i s t a b = IndexedFold a i s t a b
+type IndexedGetterP i s a = IndexedGetter i s s a a
+
+-- | An indexed setter.
+type IndexedSetter i s t a b = IndexedOptic Function i s t a b
+type IndexedSetterP i s a = IndexedSetter i s s a a


### PR DESCRIPTION
The solution for indexed optics used by `lens` does not work with profunctor optics. Indexed optics are very useful however, even if their index can't be implicitly forgotten like in `lens`. Here, I experimented with the following compromise:

For each profunctor `p` there is a profunctor `Indexed p i` with which we can define indexed optics by

``` purescript
type IndexedOptic p i s t a b = Indexed p i a b -> p s t
```

This _does not_ compose to the right with `Optic`s or other `IndexedOptics`, but composes to the left with `Optic`s. If one has an `IndexedOptic` and wishes to compose it to the right with another `Optic` or `IndexedOptic`, one can use

``` purescript
unIndex
  :: forall p i s t a b. (Profunctor p)
  => IndexedOptic p i s t a b -> Optic p s t a b
```

to _explicity_ convert an `IndexedOptic` to an `Optic` by forgetting indices. Despite of a bit of syntactic inconvenience, I reckon that this is a small price to pay. What do you think?

On that note, what would be a sensible place to put an `IndexedTraversable` type class like the following in the purescript ecosystem?

``` purescript
class (Traversable t) <= IndexedTraversable i t where
  itraverse :: forall f a b. (Applicative f) => (i -> a -> f b) -> t a -> f (t b)
```
