### PR TITLE
added traverseOf_ to the exports of Data.Lens.Fold

### DIFF
--- a/src/Data/Lens/Fold.purs
+++ b/src/Data/Lens/Fold.purs
@@ -4,8 +4,8 @@ module Data.Lens.Fold
   , (^..), toListOfOn
   , preview, foldOf, foldMapOf, foldrOf, foldlOf, toListOf, firstOf, lastOf
   , maximumOf, minimumOf, allOf, anyOf, andOf, orOf, elemOf, notElemOf, sumOf
-  , productOf, lengthOf, findOf, sequenceOf_, has, hasn't, replicated, filtered
-  , folded, unfolded
+  , productOf, lengthOf, findOf, sequenceOf_, traverseOf_, has, hasn't
+  , replicated, filtered, folded, unfolded
   , ifoldMapOf, ifoldrOf, ifoldlOf, iallOf, ianyOf, itoListOf, itraverseOf_
   , module ExportTypes
   )


### PR DESCRIPTION
Title says it all

Not sure, if the exports had some structure, maybe i destroyed that

Fixing my own issue #45