### PR TITLE
Add `Semigroup` and `Monoid` instances for `Forget`

### DIFF
--- a/src/Data/Lens/Internal/Forget.purs
+++ b/src/Data/Lens/Internal/Forget.purs
@@ -22,6 +22,10 @@ newtype Forget r a b = Forget (a -> r)
 
 derive instance newtypeForget :: Newtype (Forget r a b) _
 
+derive newtype instance semigroupForget :: Semigroup r => Semigroup (Forget r a b)
+
+derive newtype instance monoidForget :: Monoid r => Monoid (Forget r a b)
+
 instance profunctorForget :: Profunctor (Forget r) where
   dimap f _ (Forget z) = Forget (z <<< f)
 


### PR DESCRIPTION
Fixes #34.