### PR TITLE
Affine traversal

### DIFF
--- a/src/Data/Lens/Index.purs
+++ b/src/Data/Lens/Index.purs
@@ -7,54 +7,52 @@ import Prelude
 
 import Data.Array as A
 import Data.Identity (Identity)
-import Data.Lens.Internal.Wander (wander)
-import Data.Lens.Types (Traversal')
+import Data.Lens (Prism', _1, _2, _Just, lens, prism')
+import Data.Lens.Iso.Newtype (_Newtype)
+import Data.Lens.Types (AffineTraversal')
 import Data.Map as M
-import Data.Maybe (Maybe, maybe, fromMaybe)
+import Data.Maybe (Maybe(..), maybe)
 import Data.Set as S
 import Data.StrMap as SM
-import Data.Traversable (traverse)
+import Data.Tuple.Nested (Tuple3, tuple3, uncurry3)
 
 class Index m a b | m -> a, m -> b where
-  ix :: a -> Traversal' m b
+  ix :: a -> AffineTraversal' m b
 
-instance indexArr :: Eq i => Index (i -> a) i a where
-  ix i =
-    wander \coalg f ->
-      coalg (f i) <#> \a j ->
-        if i == j then a else f j
+instance indexFn :: Eq i => Index (i -> a) i a where
+  ix i = lens (\f -> f i) \f a j -> if i == j then a else f j
 
 instance indexMaybe :: Index (Maybe a) Unit a where
-  ix _ = wander traverse
+  ix _ = _Just
 
 instance indexIdentity :: Index (Identity a) Unit a where
-  ix _ = wander traverse
+  ix _ = _Newtype
 
 instance indexArray :: Index (Array a) Int a where
-  ix n =
-    wander \coalg xs ->
-      xs A.!! n #
-        maybe
-          (pure xs)
-          (coalg >>> map \x -> fromMaybe xs (A.updateAt n x xs))
+  ix n = separateIndex <<< _2 <<< _1
+    where
+      separateIndex :: Prism' (Array a) (Tuple3 (Array a) a (Array a))
+      separateIndex = prism'
+        (uncurry3 \l e r -> l <> [e] <> r)
+        \as -> A.index as n <#> \e -> tuple3
+          (A.take n as) e (A.drop (n+1) as)
 
 instance indexSet :: Ord a => Index (S.Set a) a Unit where
-  ix x =
-    wander \coalg ->
-      pure <<< S.insert x
+  ix x = lens get (flip update) <<< _Just
+    where
+      get xs =
+        if S.member x xs
+           then Just unit
+           else Nothing
+      update Nothing = S.delete x
+      update (Just _) = S.insert x
 
 instance indexMap :: Ord k => Index (M.Map k v) k v where
-  ix k =
-    wander \coalg m ->
-      M.lookup k m #
-        maybe
-          (pure m)
-          (coalg >>> map \v -> M.insert k v m)
+  ix k = _Just >>>
+    lens (M.lookup k) \m ->
+      maybe (M.delete k m) \v -> M.insert k v m
 
 instance indexStrMap :: Index (SM.StrMap v) String v where
-  ix k =
-    wander \coalg m ->
-      SM.lookup k m #
-        maybe
-          (pure m)
-          (coalg >>> map \v -> SM.insert k v m)
+  ix k = _Just >>>
+    lens (SM.lookup k) \m ->
+      maybe (SM.delete k m) \ v -> SM.insert k v m

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -59,6 +59,10 @@ type Prism' s a = Prism s s a a
 type APrism s t a b = Optic (Market a b) s t a b
 type APrism' s a = APrism s s a a
 
+-- | An affine traversal (has at most one focus, but is not a prism).
+type AffineTraversal s t a b = forall p. Strong p => Choice p => Optic p s t a b
+type AffineTraversal' s a = AffineTraversal s s a a
+
 -- | A traversal.
 type Traversal s t a b = forall p. Wander p => Optic p s t a b
 type Traversal' s a = Traversal s s a a


### PR DESCRIPTION
I don't know of any useful operations that operate specifically on affine traversals, but the type synonym is nice just to help demarcate something that is just `Lens + Prism` (composed together) versus something that is actually a `Traversal` (with potentially many foci).

In addition, the `Index` class really generates an `AffineTraversal`, so I rewrote those methods to allow that restriction. Maybe it's better to merge it with `At`, so `index i = at i <<< _Just`?

`element` should also really produce an `AffineTraversal`, but I haven't figured out how to do that yet. Maybe something with `Fold` and `Setter` ...