### PR TITLE
A start at documentation

### DIFF
--- a/src/Data/Lens/At.purs
+++ b/src/Data/Lens/At.purs
@@ -16,8 +16,8 @@ import Data.Newtype (unwrap)
 import Data.Lens (Lens', lens)
 import Data.Lens.Index (class Index)
 
--- | Use an `At` lens if you want to add
--- | new elements or delete old ones:
+-- | `At` is a type class whose instances let you add
+-- | new elements or delete old ones from "container-like" types:
 -- | 
 -- | ```purescript 
 -- | whole = Map.singleton "key" "value"
@@ -30,7 +30,7 @@ import Data.Lens.Index (class Index)
 -- | set optic Nothing whole == Map.empty
 -- | ```
 -- |
--- | If you want neither of those things, but only to view or change
+-- | If you don't want to add or delete, but only to view or change
 -- | an existing element, see `Data.Lens.Index`. 
 
 class Index m a b <= At m a b | m -> a, m -> b where

--- a/src/Data/Lens/At.purs
+++ b/src/Data/Lens/At.purs
@@ -16,24 +16,22 @@ import Data.Newtype (unwrap)
 import Data.Lens (Lens', lens)
 import Data.Lens.Index (class Index)
 
-
--- | `At` is useful for types like `Data.Map`:
--- | 
--- | * The result of getting an element is a `Maybe a`. 
--- | * New elements can be added.
--- | * Existing elements can be deleted.
+-- | Use an `At` lens if you want to add
+-- | new elements or delete old ones:
 -- | 
 -- | ```purescript 
--- | > optic = at "key"
--- | > view optic $ Map.singleton "key" "value"
--- | (Just "value")
+-- | whole = Map.singleton "key" "value"
+-- | optic = at "key"
+-- |
+-- | view optic whole == Just "value"
 -- | 
--- | > set optic (Just "NEW") $ Map.singleton "key" "value"
--- | (fromFoldable [(Tuple "key" "NEW")])
+-- | set optic (Just "NEW") whole == Map.singleton "key" "NEW"
 -- | 
--- | > set optic Nothing $ Map.singleton "key" "value"
--- | (fromFoldable [])
+-- | set optic Nothing whole == Map.empty
 -- | ```
+-- |
+-- | If you want neither of those things, but only to view or change
+-- | an existing element, see `Data.Lens.Index`. 
 
 class Index m a b <= At m a b | m -> a, m -> b where
   at :: a -> Lens' m (Maybe b)

--- a/src/Data/Lens/At.purs
+++ b/src/Data/Lens/At.purs
@@ -3,6 +3,7 @@ module Data.Lens.At
   , at
   ) where
 
+
 import Prelude
 
 import Data.Identity (Identity(..))
@@ -14,6 +15,25 @@ import Data.Newtype (unwrap)
 
 import Data.Lens (Lens', lens)
 import Data.Lens.Index (class Index)
+
+
+-- | `At` is useful for types like `Data.Map`:
+-- | 
+-- | * The result of getting an element is a `Maybe a`. 
+-- | * New elements can be added.
+-- | * Existing elements can be deleted.
+-- | 
+-- | ```purescript 
+-- | > optic = at "key"
+-- | > view optic $ Map.singleton "key" "value"
+-- | (Just "value")
+-- | 
+-- | > set optic (Just "NEW") $ Map.singleton "key" "value"
+-- | (fromFoldable [(Tuple "key" "NEW")])
+-- | 
+-- | > set optic Nothing $ Map.singleton "key" "value"
+-- | (fromFoldable [])
+-- | ```
 
 class Index m a b <= At m a b | m -> a, m -> b where
   at :: a -> Lens' m (Maybe b)

--- a/src/Data/Lens/Index.purs
+++ b/src/Data/Lens/Index.purs
@@ -15,22 +15,32 @@ import Data.Set as S
 import Data.StrMap as SM
 import Data.Traversable (traverse)
 
--- | `Index` is useful when a focus element might not be present.
--- | It allows you to `set` an existing focus element, but you cannot add a
--- | new one or delete an old one.
--- | 
+-- | Use an `Index` optic on types where: 
+-- | 1. The focus element might not be present.
+-- | 2. You either cannot or do not want to add new elements or delete existing ones. 
+-- |
+-- | `Array` is a typical example:
+-- |
 -- | ```purescript 
--- |> optic = ix 1
--- |> preview optic [0, 1, 2]
--- |(Just 1)
+-- | preview (ix 1) [0, 1, 2] == Just 1
 -- |
--- |> set optic 8888 [0, 1, 2]
--- |[0,8888,2]
--- |
--- |-- Note that `Index` lenses work with many types:
--- |> over optic negate $ Map.singleton 1 8888
--- |(fromFoldable [(Tuple 1 -8888)])
+-- | set (ix 1) 8888 [0, 1, 2] == [0,8888,2]
 -- | ```
+-- |
+-- | Note the use of `preview` rather `view`.
+-- | 
+-- | Another common use is a `Map` that you don't want to either grow or shrink:
+-- |
+-- | ```purescript 
+-- | (set (ix 1) 8888 $ Map.singleton 1 2) == Map.singleton 1 8888
+-- | 
+-- | (set (ix 1) 8888 $ Map.empty) == Map.empty
+-- | ```
+-- |
+-- | Note the second line: an attempt to `set` a missing focus element
+-- | leaves the original whole unchanged.
+-- |
+-- | If you *do* want to add or delete elements, see `Data.Lens.At`. 
 
 class Index m a b | m -> a, m -> b where
   ix :: a -> Traversal' m b

--- a/src/Data/Lens/Index.purs
+++ b/src/Data/Lens/Index.purs
@@ -15,7 +15,7 @@ import Data.Set as S
 import Data.StrMap as SM
 import Data.Traversable (traverse)
 
--- | Use an `Index` optic on types where: 
+-- | `Index` is a type class whose instances are optics used when:
 -- | 1. The focus element might not be present.
 -- | 2. You either cannot or do not want to add new elements or delete existing ones. 
 -- |
@@ -27,14 +27,16 @@ import Data.Traversable (traverse)
 -- | set (ix 1) 8888 [0, 1, 2] == [0,8888,2]
 -- | ```
 -- |
--- | Note the use of `preview` rather `view`.
+-- | Note the use of `preview` rather `view`. That's because the optic is 
+-- | a `Data.Lens.Traversal` tailored to the case where there's a single element
+-- | of interest.
 -- | 
 -- | Another common use is a `Map` that you don't want to either grow or shrink:
 -- |
 -- | ```purescript 
--- | (set (ix 1) 8888 $ Map.singleton 1 2) == Map.singleton 1 8888
+-- | (set (ix "k") "new" $ Map.singleton "k" "old") == Map.singleton "k" "new"
 -- | 
--- | (set (ix 1) 8888 $ Map.empty) == Map.empty
+-- | (set (ix "k") "new" $ Map.empty) == Map.empty
 -- | ```
 -- |
 -- | Note the second line: an attempt to `set` a missing focus element

--- a/src/Data/Lens/Index.purs
+++ b/src/Data/Lens/Index.purs
@@ -15,6 +15,23 @@ import Data.Set as S
 import Data.StrMap as SM
 import Data.Traversable (traverse)
 
+-- | `Index` is useful when a focus element might not be present.
+-- | It allows you to `set` an existing focus element, but you cannot add a
+-- | new one or delete an old one.
+-- | 
+-- | ```purescript 
+-- |> optic = ix 1
+-- |> preview optic [0, 1, 2]
+-- |(Just 1)
+-- |
+-- |> set optic 8888 [0, 1, 2]
+-- |[0,8888,2]
+-- |
+-- |-- Note that `Index` lenses work with many types:
+-- |> over optic negate $ Map.singleton 1 8888
+-- |(fromFoldable [(Tuple 1 -8888)])
+-- | ```
+
 class Index m a b | m -> a, m -> b where
   ix :: a -> Traversal' m b
 

--- a/src/Data/Lens/Lens.purs
+++ b/src/Data/Lens/Lens.purs
@@ -24,12 +24,23 @@ import Data.Profunctor.Strong (first)
 import Data.Tuple (Tuple(..))
 import Data.Newtype(un)
 
-lens' :: forall s t a b. (s -> Tuple a (b -> t)) -> Lens s t a b
-lens' to pab = dimap to (\(Tuple b f) -> f b) (first pab)
-
 -- | Create a `Lens` from a getter/setter pair.
+-- |
+-- | ```purescript
+-- | > species = lens _.species $ _ {species = _}
+-- | > view species {species : "bovine"}
+-- | "bovine"
+-- |
+-- | > _2 = lens Tuple.snd $ \(Tuple keep _) new -> Tuple keep new
+-- | ```
+-- |
+-- | Note: `_2` is predefined in `Data.Lens.Tuple`.
+
 lens :: forall s t a b. (s -> a) -> (s -> b -> t) -> Lens s t a b
 lens get set = lens' \s -> Tuple (get s) \b -> set s b
+
+lens' :: forall s t a b. (s -> Tuple a (b -> t)) -> Lens s t a b
+lens' to pab = dimap to (\(Tuple b f) -> f b) (first pab)
 
 withLens :: forall s t a b r. ALens s t a b -> ((s -> a) -> (s -> b -> t) -> r) -> r
 withLens l f = case l (Shop id \_ b -> b) of Shop x y -> f x y

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -27,20 +27,44 @@ import Data.Profunctor.Choice (class Choice)
 import Data.Profunctor.Closed (class Closed)
 import Data.Profunctor.Strong (class Strong)
 
--- | A general-purpose Data.Lens.
-type Optic p s t a b = p a b -> p s t
-type Optic' p s a = Optic p s s a a
+-- | Given a type whose "focus element" can always be retrieved,
+-- | a lens provides a convenient way to view, get, and transform
+-- | that element. 
+-- | 
+-- | `_2` is a Tuple-specific `Lens` available from `Data.Lens`, so:
+-- | ```purescript
+-- | > import Data.Lens
+-- | > over _2 String.length $ Tuple "ignore" "four"
+-- | (Tuple "ignore" 4)
+-- | ```
+type Lens s t a b = forall p. Strong p => Optic p s t a b
+
+-- | `Lens` allows `set` to change the type of the focus. Often, a
+-- | particular lens won't do that. This type alias declares that `set`
+-- | only changes values, not types.
+type Lens' s a = Lens s s a a
+
+-- | A prism.
+type Prism s t a b = forall p. Choice p => Optic p s t a b
+type Prism' s a = Prism s s a a
 
 -- | A generalized isomorphism.
 type Iso s t a b = forall p. Profunctor p => Optic p s t a b
 type Iso' s a = Iso s s a a
 
+-- | A traversal.
+type Traversal s t a b = forall p. Wander p => Optic p s t a b
+type Traversal' s a = Traversal s s a a
+
+
+
+
+-- | A general-purpose Data.Lens.
+type Optic p s t a b = p a b -> p s t
+type Optic' p s a = Optic p s s a a
+
 type AnIso s t a b = Optic (Exchange a b) s t a b
 type AnIso' s a = AnIso s s a a
-
--- | A lens.
-type Lens s t a b = forall p. Strong p => Optic p s t a b
-type Lens' s a = Lens s s a a
 
 type ALens s t a b = Optic (Shop a b) s t a b
 type ALens' s a = ALens s s a a
@@ -52,16 +76,8 @@ type IndexedLens' i s a = IndexedLens i s s a a
 type AnIndexedLens i s t a b = IndexedOptic (Shop (Tuple i a) b) i s t a b
 type AnIndexedLens' i s a = AnIndexedLens i s s a a
 
--- | A prism.
-type Prism s t a b = forall p. Choice p => Optic p s t a b
-type Prism' s a = Prism s s a a
-
 type APrism s t a b = Optic (Market a b) s t a b
 type APrism' s a = APrism s s a a
-
--- | A traversal.
-type Traversal s t a b = forall p. Wander p => Optic p s t a b
-type Traversal' s a = Traversal s s a a
 
 -- | A grate (http://r6research.livejournal.com/28050.html)
 type Grate s t a b = forall p. Closed p => Optic p s t a b

--- a/src/Data/Lens/Types.purs
+++ b/src/Data/Lens/Types.purs
@@ -27,21 +27,53 @@ import Data.Profunctor.Choice (class Choice)
 import Data.Profunctor.Closed (class Closed)
 import Data.Profunctor.Strong (class Strong)
 
--- | Given a type whose "focus element" can always be retrieved,
--- | a lens provides a convenient way to view, get, and transform
+-- | Given a type whose "focus element" always exists,
+-- | a lens provides a convenient way to view, set, and transform
 -- | that element. 
 -- | 
--- | `_2` is a Tuple-specific `Lens` available from `Data.Lens`, so:
+-- | For example, `_2` is a tuple-specific `Lens` available from `Data.Lens`, so:
 -- | ```purescript
--- | > import Data.Lens
--- | > over _2 String.length $ Tuple "ignore" "four"
--- | (Tuple "ignore" 4)
+-- | over _2 String.length $ Tuple "ignore" "four" == Tuple "ignore" 4
 -- | ```
+-- | Note the result has a different type than the original tuple.
+-- | That is, the four `Lens` type variables have been narrowed to:
+-- |
+-- | * `s` is `Tuple String String`
+-- | * `t` is `Tuple String Int`
+-- | * `a` is `String`
+-- | * `b` is `Int`
+-- | 
+-- | See `Data.Lens.Getter` and `Data.Lens.Setter` for functions and operators
+-- | frequently used with lenses.
+
+
 type Lens s t a b = forall p. Strong p => Optic p s t a b
 
--- | `Lens` allows `set` to change the type of the focus. Often, a
--- | particular lens won't do that. This type alias declares that `set`
--- | only changes values, not types.
+-- | `Lens'` is a specialization of `Lens`. An optic of type `Lens'`
+-- | can change only the value of its focus,
+-- | not its type. As an example, consider the `Lens` `_2`, which has this type:
+-- |
+-- | ```purescript
+-- | _2 :: forall s t a b. Lens (Tuple s a) (Tuple t b) a b 
+-- | ```
+-- |
+-- | `_2` can produce a `Tuple Int String` from a `Tuple Int Int`:
+-- |
+-- | ```purescript
+-- | set _2 "NEW" (Tuple 1 2) == (Tuple 1 "NEW")
+-- | ```
+-- |
+-- | If we specialize `_2`'s type with `Lens'`, the following will not
+-- | type check:
+-- |
+-- | ```purescript
+-- | set (_2 :: Lens' (Tuple Int Int) Int) "NEW" (Tuple 1 2)
+-- |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+-- | ```
+-- |
+-- | See `Data.Lens.Getter` and `Data.Lens.Setter` for functions and operators
+-- | frequently used with lenses.
+
 type Lens' s a = Lens s s a a
 
 -- | A prism.


### PR DESCRIPTION
This pull request shows the sort of documentation I (as a beginner) would have liked to see when I started using this package. See #82.

There are two sorts of changes:

1. I added commentary, with examples, to type classes, types, and functions.
2. I reordered definitions so the more important functions came first. (For example, I really think a reader should encounter `lens` before `lens'`. 



