### PR TITLE
Support inverse of `lens'`

### DIFF
--- a/src/Data/Lens.purs
+++ b/src/Data/Lens.purs
@@ -25,7 +25,7 @@ module Data.Lens
 
 import Data.Lens.Iso (AnIso, AnIso', Iso, Iso', Optic, Exchange(..), Re(..), au, auf, cloneIso, non, curried, flipped, iso, re, uncurried, under, withIso)
 import Data.Lens.Grate (Grate, Grate', zipWithOf, zipFWithOf, collectOf)
-import Data.Lens.Lens (ALens, ALens', Lens, Lens', cloneLens, lens, lens', withLens)
+import Data.Lens.Lens (ALens, ALens', Lens, Lens', cloneLens, lens, lens', withLens, lensStore)
 import Data.Lens.Prism (APrism, APrism', Prism, Prism', Review, Review', clonePrism, is, isn't, matching, nearly, only, prism, prism', review, withPrism)
 import Data.Lens.Traversal (Traversal, Traversal', element, elementsOf, failover, itraverseOf, sequenceOf, traverseOf, traversed)
 import Data.Lens.Types (class Wander, ALens, ALens', APrism, APrism', AnIso, AnIso', Fold, Fold', Getter, Getter', AGetter, AGetter', IndexedFold, IndexedFold', IndexedGetter, IndexedGetter', IndexedOptic, IndexedOptic', IndexedSetter, IndexedSetter', IndexedTraversal, IndexedTraversal', Iso, Iso', Lens, Lens', Optic, Optic', Prism, Prism', Review, Review', Setter, Setter', Traversal, Traversal', Exchange(..), Forget(..), Indexed(..), Market(..), Re(..), Shop(..), Tagged(..), wander)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.State (evalState, get)
 import Data.Distributive (class Distributive)
 import Data.Either (Either(..))
-import Data.Lens (Getter', Prism', _1, _2, _Just, _Left, collectOf, lens, preview, prism', takeBoth, toArrayOf, traversed, view)
+import Data.Lens (Getter', Prism', _1, _2, _Just, _Left, collectOf, lens, lens', preview, prism', takeBoth, toArrayOf, traversed, view, lensStore)
 import Data.Lens.Fold ((^?))
 import Data.Lens.Fold.Partial ((^?!), (^@?!))
 import Data.Lens.Grate (Grate, cloneGrate, grate, zipWithOf)
@@ -120,6 +120,14 @@ cloneTraversalTest =
       wrapper :: { traversal :: ATraversal' (Array Int) Int }
       wrapper = { traversal: t }
   in preview (cloneTraversal wrapper.traversal) [ 0, 1, 2 ]
+
+-- lensStore example
+data LensStoreExample = LensStoreA Int | LensStoreB (Tuple Boolean Int)
+
+lensStoreExampleInt :: Lens' LensStoreExample Int
+lensStoreExampleInt = lens' case _ of
+  LensStoreA i -> map LensStoreA <$> lensStore identity i
+  LensStoreB i -> map LensStoreB <$> lensStore _2 i
 
 main :: Effect Unit
 main = do


### PR DESCRIPTION
#### Edit

`lens'` converts a store-style lens `s -> Tuple a (b -> t)` to a profunctor-style lens.  Supporting a conversion in the inverse direction would help with embedding existing lenses in new ones (see the original description and following conversation for examples).

#### Original description:

This change adds a helper function for when you want a lens over a sum-type.  For example:

```purescript
data X = A Int | B (Tuple Boolean Int)

xInt :: Lens' X Int
xInt = lens' case _ of
  A i -> sumLens identity A i
  B i -> sumLens _2 B i
```

I don't know if anything like this already exists.
Also would appreciate suggestions of a better name :sweat_smile: 