### PR TITLE
Add `simple` for helping type inference

### DIFF
--- a/src/Data/Lens/Common.purs
+++ b/src/Data/Lens/Common.purs
@@ -4,9 +4,39 @@ module Data.Lens.Common
   , module Data.Lens.Lens.Unit
   , module Data.Lens.Prism.Either
   , module Data.Lens.Prism.Maybe
+  , simple
   ) where
 
+import Data.Lens.Types (Optic')
 import Data.Lens.Lens.Tuple (_1, _2, first, second)
 import Data.Lens.Lens.Unit (united)
 import Data.Lens.Prism.Either (_Left, _Right, left, right)
 import Data.Lens.Prism.Maybe (_Just, _Nothing)
+
+-- | This is useful for when you want to restrict the type of another optic.
+-- | For example, suppose you have the following declarations:
+-- | ```purescript
+-- | newtype X = X Int
+-- | derive instance newtypeX :: Newtype X _
+-- | ```
+-- |
+-- | Attempting to view with the `_Newtype` optic:
+-- | ```purescript
+-- | X 42 ^. _Newtype
+-- | ```
+-- | Will result in a type error:
+-- | ```
+-- |  The inferred type
+-- |    forall t3 t5. Newtype t3 t5 => Int
+-- |  has type variables which are not mentioned in the body of the type.
+-- |  Consider adding a type annotation.
+-- | ```
+-- |
+-- | However, if we apply the `simple` function:
+-- | ```purescript
+-- |  X 42 ^. simple _Newtype
+-- | ```
+-- | We get the expected result `42`.
+simple :: forall p s a . Optic' p s a -> Optic' p s a
+simple x = x
+

--- a/src/Data/Lens/Iso/Newtype.purs
+++ b/src/Data/Lens/Iso/Newtype.purs
@@ -3,5 +3,11 @@ module Data.Lens.Iso.Newtype where
 import Data.Lens.Iso (Iso, iso)
 import Data.Newtype (class Newtype, wrap, unwrap)
 
+-- | An Iso between a newtype and its inner type.
+-- | Supports switching between different types that have instances of the
+-- | Newtype type class.
+-- | If you don't need to change types, you may have a better experience with
+-- | type inference if you use `simple _Newtype`.
 _Newtype :: forall t a s b. Newtype t a => Newtype s b => Iso t s a b
 _Newtype = iso unwrap wrap
+


### PR DESCRIPTION
Relating to https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/98
Here's an example scenario:

```purescript
> import Prelude
> import Data.Newtype
> import Data.Lens
> import Data.Lens.Iso.Newtype
> import Data.Lens.Common
> newtype X = X Int
> derive instance newtypeX :: Newtype X _
> X 42 ^. _Newtype
Error found:
in module $PSCI
at <internal> line 0, column 0 - line 0, column 0
  The inferred type
    forall t3 t5. Newtype t3 t5 => Int
  has type variables which are not mentioned in the body of the type. Consider adding a type annotation.

> X 42 ^. simple _Newtype
42
```

Wasn't sure where to put it, currently in `Data.Lens.Common`.