### PR TITLE
Remove redundant Applicative constraints

### DIFF
--- a/src/Data/Lens/Traversal.purs
+++ b/src/Data/Lens/Traversal.purs
@@ -54,12 +54,10 @@ traversed = wander traverse
 
 -- | Turn a pure profunctor `Traversal` into a `lens`-like `Traversal`.
 traverseOf
-  :: forall f s t a b
-   . Applicative f
-  => Optic (Star f) s t a b -> (a -> f b) -> s -> f t
+  :: forall f s t a b . Optic (Star f) s t a b -> (a -> f b) -> s -> f t
 traverseOf = under Star
 
--- | Sequence the foci of a `Traversal`, pulling out an `Applicative` effect.
+-- | Sequence the foci of an optic, pulling out an "effect".
 -- | If you do not need the result, see `sequenceOf_` for `Fold`s.
 -- |
 -- | `sequenceOf traversed` has the same result as `Data.Traversable.sequence`:
@@ -83,11 +81,8 @@ traverseOf = under Star
 -- | [0.15556037108154985,0.28500369615270515]
 -- | unit
 -- | ```
-
 sequenceOf
-  :: forall f s t a
-   . Applicative f
-  => Optic (Star f) s t (f a) a -> s -> f t
+  :: forall f s t a . Optic (Star f) s t (f a) a -> s -> f t
 sequenceOf t = traverseOf t identity
 
 -- | Tries to map over a `Traversal`; returns `empty` if the traversal did
@@ -134,8 +129,7 @@ elementsOf tr pr = iwander \f ->
 -- | Turn a pure profunctor `IndexedTraversal` into a `lens`-like `IndexedTraversal`.
 itraverseOf
   :: forall f i s t a b
-  . Applicative f
-  => IndexedOptic (Star f) i s t a b
+  .  IndexedOptic (Star f) i s t a b
   -> (i -> a -> f b)
   -> s
   -> f t
@@ -144,8 +138,7 @@ itraverseOf t = under Star (t <<< Indexed) <<< uncurry
 -- | Flipped version of `itraverseOf`.
 iforOf
   :: forall f i s t a b
-  . Applicative f
-  => IndexedOptic (Star f) i s t a b
+  .  IndexedOptic (Star f) i s t a b
   -> s
   -> (i -> a -> f b)
   -> f t


### PR DESCRIPTION
These functions in `Data.Lens.Traversal` had redundant constraints.