### PR TITLE
Fix Data.Lens.Zoom.zoom

### DIFF
--- a/src/Data/Lens/Zoom.purs
+++ b/src/Data/Lens/Zoom.purs
@@ -19,4 +19,4 @@ zoom
    . Optic' (Star (Focusing m r)) s a
   -> StateT a m r
   -> StateT s m r
-zoom p = StateT <<< underF Focusing (under Star p) <<< runStateT
+zoom p = StateT <<< underF Focusing (under Star p :: (a -> Focusing m r a) -> s -> Focusing m r s) <<< runStateT


### PR DESCRIPTION
Without the type annotation Data.Lens.Zoom.zoom yields the following error:

```
[1/1 NoInstanceFound] src/Data/Lens/Zoom.purs:22:21

  22  zoom p = StateT <<< underF Focusing (under Star p) <<< runStateT
                          ^^^^^^^^^^^^^^^

  No type class instance was found for

    Prim.Coerce.Coercible t4
                          (m7 (Tuple r8 s6))

  The instance head contains unknown type variables. Consider adding a type annotation.

  while solving type class constraint

    Prim.Coerce.Coercible (s6 -> t4)
                          (s6 -> m7 (Tuple r8 s6))

  while applying a function underF
    of type Coercible @Type (t0 t1) (t0 t2) => Coercible @Type (t3 t4) (t3 t5) => Newtype t1 t2 => Newtype t4 t5 => (t2 -> t1) -> (t0 t1 -> t3 t4) -> t0 t2 -> t3 t5
    to argument Focusing
  while inferring the type of underF Focusing
  in value declaration zoom

  where s6 is a rigid type variable
          bound at (line 0, column 0 - line 0, column 0)
        r8 is a rigid type variable
          bound at (line 0, column 0 - line 0, column 0)
        m7 is a rigid type variable
          bound at (line 0, column 0 - line 0, column 0)
        t0 is an unknown type
        t3 is an unknown type
        t1 is an unknown type
        t2 is an unknown type
        t4 is an unknown type
        t5 is an unknown type
```

I suspect this happens because the functional dependency computing `s -> Focusing m r s` from `Star (Focusing m r) s s` in `under Star p` doesn’t propagate its result, so the compiler cannot solve the Coercible constraints implied by the Newtype constraints in `underF Focusing (under Star p)`.