### PR TITLE
Replace logShow with assertEquals'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+ - Replace manual tests with automated tests using `assert` #135 by @neppord
 
 ## [v7.0.1](https://github.com/purescript-contrib/purescript-profunctor-lenses/releases/tag/v7.0.1) - 2021-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
- - Replace manual tests with automated tests using `assert` #135 by @neppord
+ - Replace manual tests with automated tests using `assert` (#135 by @neppord)
 
 ## [v7.0.1](https://github.com/purescript-contrib/purescript-profunctor-lenses/releases/tag/v7.0.1) - 2021-05-06
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,6 +1,7 @@
 { name = "profunctor-lenses"
 , dependencies =
   [ "arrays"
+  , "assert"
   , "bifunctors"
   , "console"
   , "const"


### PR DESCRIPTION
I wanted to make it easier to add automated tests, and so I started by converting the manual ones that already existed.

Working from the principles of iterative improvement, this PR is not perfect but I'm quite sure it is better then the code that existed, and hope the next person (maybe me) will improve it further.

The asserts did not get good names since I don't know what they intended with the test, but at least they are easy to find due to the unique names they have, since they are named by the expression it tests.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
