### PR TITLE
Fix broken reindexed due to change in operator precedence (v0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 - Add `sans` and `both` (#97 by @xgrommx)
 
 Bugfixes:
+- Fix broken `reindex` for v0.15 due to [Purescript PR #4033](https://github.com/purescript/purescript/pull/4033)
 
 Other improvements:
 - Added `purs-tidy` formatter (#138 by @thomashoneyman)

--- a/src/Data/Lens/Indexed.purs
+++ b/src/Data/Lens/Indexed.purs
@@ -37,7 +37,7 @@ reindexed
   -> (Indexed p i a b -> r)
   -> Indexed p j a b
   -> r
-reindexed ij = (_ <<< _Newtype %~ lcmap (first ij))
+reindexed ij = (_ <<< (_Newtype %~ lcmap (first ij)))
 
 -- | Converts a `lens`-like indexed traversal to an `IndexedTraversal`.
 iwander


### PR DESCRIPTION
**Fix broken reindexed**
This fixes broken `reindexed` due to [PR #4033](https://github.com/purescript/purescript/pull/4033) in the purescript compiler for the upcoming v0.15 release. Thx to @nwolverson for pointing out how to fix this.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
