### PR TITLE
 Add `prop` variant using VTA 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added a variant of `prop` in `Data.Lens.Record.VTA` that supplies the `Symbol` via VTA (visible type application) instead of via `Proxy` (#145 by @amesgen)
 
 Bugfixes:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.10-20230719/src/packages.dhall
+        sha256:dfc2383cad9ae1beea830197d36ef39aed9d4cd587c0af04b8fce252209a2f0d
 
 in  upstream

--- a/src/Data/Lens/Record/VTA.purs
+++ b/src/Data/Lens/Record/VTA.purs
@@ -1,0 +1,27 @@
+module Data.Lens.Record.VTA (prop) where
+
+import Data.Lens (Lens)
+import Data.Symbol (class IsSymbol)
+import Prim.Row as Row
+import Type.Proxy (Proxy(..))
+import Data.Lens.Record as Data.Lens.Record
+
+-- | Construct a (type-changing) lens for a record property, by providing a
+-- | `Symbol` via VTA (visible type application) which corresponds to the
+-- | property label.
+-- |
+-- | The lens is polymorphic in the rest of the row of property labels.
+-- |
+-- | For example:
+-- |
+-- | ```purescript
+-- | prop @"foo"
+-- |   :: forall a b r. Lens { foo :: a | r } { foo :: b | r } a b
+-- | ```
+prop
+  :: forall @l r1 r2 r a b
+   . IsSymbol l
+  => Row.Cons l a r r1
+  => Row.Cons l b r r2
+  => Lens (Record r1) (Record r2) a b
+prop = Data.Lens.Record.prop (Proxy @l)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,6 +12,7 @@ import Data.Lens.Index (ix)
 import Data.Lens.Indexed (itraversed, reindexed)
 import Data.Lens.Lens (IndexedLens, cloneIndexedLens, ilens)
 import Data.Lens.Record (prop)
+import Data.Lens.Record.VTA as VTA
 import Data.Lens.Setter (iover)
 import Data.Lens.Traversal (cloneTraversal)
 import Data.Lens.Zoom (ATraversal', IndexedTraversal', Lens, Lens', Traversal, Traversal', zoom)
@@ -27,6 +28,12 @@ foo = prop (Proxy :: Proxy "foo")
 
 bar :: forall a b r. Lens { bar :: a | r } { bar :: b | r } a b
 bar = prop (Proxy :: Proxy "bar")
+
+foo' :: forall a b r. Lens { foo :: a | r } { foo :: b | r } a b
+foo' = VTA.prop @"foo"
+
+bar' :: forall a b r. Lens { bar :: a | r } { bar :: b | r } a b
+bar' = VTA.prop @"bar"
 
 barAndFoo :: forall a b r. Getter' { bar :: a, foo :: b | r } (Tuple a b)
 barAndFoo = takeBoth bar foo


### PR DESCRIPTION
**Description of the change**
Adds a variant of `prop` using VTA (visible type application) which was [added in Purescript 0.15.10](https://github.com/purescript/purescript/releases/tag/v0.15.10). Motivation is mainly to save some characters:

```purescript
prop @"foo"                 :: forall a b r. Lens { foo :: a | r } { foo :: b | r } a b
```
vs
```purescript
prop (Proxy :: Proxy "foo") :: forall a b r. Lens { foo :: a | r } { foo :: b | r } a b
prop (Proxy :: _ "foo")     :: forall a b r. Lens { foo :: a | r } { foo :: b | r } a b
```

I chose to also name it `prop` and put it in a new module (as it seems very unlikely that both variants are used in the same project), but also happy to change to other alternatives, like naming it `prop'` and putting it in `Data.Lens.Record`, or simply replacing the current `prop` with the VTA-enabled `prop` (would be a breaking change).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
