### PR TITLE
Add `ifolded` and `imapped` (closes #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           npm install bower pulp@16.0.0-0
           npx bower install
-          npx pulp build -- --censor-lib --strict
+          npx pulp build
           if [ -d "test" ]; then
             npx pulp test
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
-- Add `imapped` (#146 by @twhitehead)
+- Add `ifolded` and `imapped` (#146 by @twhitehead)
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Add `imapped` (#146 by @twhitehead)
 
 Bugfixes:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.15-20240829/src/packages.dhall
 
 in  upstream

--- a/src/Data/Lens/Indexed.purs
+++ b/src/Data/Lens/Indexed.purs
@@ -6,11 +6,12 @@ import Control.Monad.State (evalState, get, modify)
 import Data.Functor.Compose (Compose(..))
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Setter ((%~))
-import Data.Lens.Types (Indexed(..), IndexedOptic, IndexedTraversal, Optic, Traversal, wander)
+import Data.Lens.Types (Indexed(..), IndexedOptic, IndexedSetter, IndexedTraversal, Optic, Traversal, wander)
 import Data.Newtype (unwrap)
 import Data.Profunctor (class Profunctor, dimap, lcmap)
 import Data.Profunctor.Star (Star(..))
 import Data.Profunctor.Strong (first)
+import Data.FunctorWithIndex (class FunctorWithIndex, mapWithIndex)
 import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Data.Tuple (curry, fst, snd)
 
@@ -45,6 +46,13 @@ iwander
    . (forall f. Applicative f => (i -> a -> f b) -> s -> f t)
   -> IndexedTraversal i s t a b
 iwander itr = wander (\f s -> itr (curry f) s) <<< unwrap
+
+-- | Sets over a `FunctorWithIndex` container.
+imapped
+  :: forall i f a b
+   . FunctorWithIndex i f
+  => IndexedSetter i (f a) (f b) a b
+imapped = mapWithIndex <<< curry <<< unwrap
 
 -- | Traverses over a `TraversableWithIndex` container.
 itraversed

--- a/src/Data/Lens/Indexed.purs
+++ b/src/Data/Lens/Indexed.purs
@@ -6,11 +6,12 @@ import Control.Monad.State (evalState, get, modify)
 import Data.Functor.Compose (Compose(..))
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Setter ((%~))
-import Data.Lens.Types (Indexed(..), IndexedOptic, IndexedSetter, IndexedTraversal, Optic, Traversal, wander)
-import Data.Newtype (unwrap)
+import Data.Lens.Types (Indexed(..), IndexedOptic, IndexedFold, IndexedSetter, IndexedTraversal, Optic, Traversal, wander)
+import Data.Newtype (wrap, unwrap)
 import Data.Profunctor (class Profunctor, dimap, lcmap)
 import Data.Profunctor.Star (Star(..))
 import Data.Profunctor.Strong (first)
+import Data.FoldableWithIndex (class FoldableWithIndex, foldMapWithIndex)
 import Data.FunctorWithIndex (class FunctorWithIndex, mapWithIndex)
 import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Data.Tuple (curry, fst, snd)
@@ -46,6 +47,14 @@ iwander
    . (forall f. Applicative f => (i -> a -> f b) -> s -> f t)
   -> IndexedTraversal i s t a b
 iwander itr = wander (\f s -> itr (curry f) s) <<< unwrap
+
+-- | Folds over a `FoldableWithIndex` container.
+ifolded
+  :: forall r i f t a b
+   . Monoid r
+  => FoldableWithIndex i f
+  => IndexedFold r i (f a) t a b
+ifolded = wrap <<< foldMapWithIndex <<< curry <<< unwrap <<< unwrap
 
 -- | Sets over a `FunctorWithIndex` container.
 imapped


### PR DESCRIPTION
**Description of the change**

This adds the `ifolded` and `imapped` functions to provide an `IndexedFold` and an `IndexedSetter` for all instances of `FoldableWithIndex` and `FunctorWithIndex` as `itraversed` provides an `IndexedTraversal` for all instances of `TraversableWithIndex`

---

**Checklist:**

- [X] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
