### PR TITLE
Add instances for HashMap/HashSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
 
 New features:
 - Add `ifolded` and `imapped` (#146 by @twhitehead)
+- Add `at`/`index` instances for `purescript-unordered-collections` (HashSet & HashMap)
 
 Bugfixes:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
       https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.15-20240829/src/packages.dhall
+        sha256:5bab5469c75bd8c7bac517385e6dd66cca0b2651676b4a99b357753c80bbe673
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -24,6 +24,7 @@
   , "safe-coerce"
   , "transformers"
   , "tuples"
+  , "unordered-collections"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Data/Lens/At.purs
+++ b/src/Data/Lens/At.purs
@@ -6,13 +6,16 @@ module Data.Lens.At
 
 import Prelude
 
+import Data.Hashable (class Hashable)
 import Data.Identity (Identity(..))
 import Data.Lens (Lens', lens, set)
 import Data.Lens.Index (class Index)
 import Data.Map as M
+import Data.HashMap as HM
 import Data.Maybe (Maybe(..), maybe, maybe')
 import Data.Newtype (unwrap)
 import Data.Set as S
+import Data.HashSet as HS
 import Foreign.Object as FO
 
 -- | `At` is a type class whose instances let you add
@@ -50,10 +53,24 @@ instance atSet :: Ord v => At (S.Set v) v Unit where
     update Nothing = S.delete x
     update (Just _) = S.insert x
 
+instance atHashSet :: Hashable v => At (HS.HashSet v) v Unit where
+  at x = lens get (flip update)
+    where
+    get xs =
+      if HS.member x xs then Just unit
+      else Nothing
+    update Nothing = HS.delete x
+    update (Just _) = HS.insert x
+
 instance atMap :: Ord k => At (M.Map k v) k v where
   at k =
     lens (M.lookup k) \m ->
       maybe' (\_ -> M.delete k m) \v -> M.insert k v m
+
+instance atHashMap :: Hashable k => At (HM.HashMap k v) k v where
+  at k =
+    lens (HM.lookup k) \m ->
+      maybe' (\_ -> HM.delete k m) \v -> HM.insert k v m
 
 instance atForeignObject :: At (FO.Object v) String v where
   at k =


### PR DESCRIPTION
**Description of the change**
This PR adds `At`/`Index` instances for HashSet/HashMap from `unordered-collections` package.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
